### PR TITLE
Change retrieving data format from json to qw

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -124,7 +124,7 @@ export class DataSource extends DataSourceApi<AAQuery, AADataSourceOptions> {
 
     const from_str = operator === 'last' ? to.toISOString() : from.toISOString();
 
-    const url = `${this.url}/data/getData.json?pv=${encodeURIComponent(pv)}&from=${from_str}&to=${to.toISOString()}`;
+    const url = `${this.url}/data/getData.qw?pv=${encodeURIComponent(pv)}&from=${from_str}&to=${to.toISOString()}`;
 
     return url;
   }
@@ -139,7 +139,7 @@ export class DataSource extends DataSourceApi<AAQuery, AADataSourceOptions> {
     const dataFramesArray = _.map(responses, response => {
       const dataFrames = _.map(response.data, targetRes => {
         const values = _.map(targetRes.data, datapoint => datapoint.val);
-        const times = _.map(targetRes.data, datapoint => datapoint.secs * 1000 + _.floor(datapoint.nanos / 1000000));
+        const times = _.map(targetRes.data, datapoint => datapoint.millis);
         const frame = new MutableDataFrame({
           name: targetRes.meta.name,
           fields: [

--- a/src/specs/aafunc.test.ts
+++ b/src/specs/aafunc.test.ts
@@ -36,9 +36,9 @@ function createDefaultResponse() {
       {
         meta: { name: 'PV', PREC: '0' },
         data: [
-          { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-          { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-          { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+          { millis: 1262304000123, val: 0 },
+          { millis: 1262304001456, val: 1 },
+          { millis: 1262304002789, val: 2 },
         ],
       },
     ],
@@ -62,8 +62,8 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: 'PV', PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ],
@@ -108,8 +108,8 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: 'PV', PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ],
@@ -154,8 +154,8 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: 'PV', PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ],
@@ -198,9 +198,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: 'PV', PREC: '0' },
             data: [
-              { secs: 1262304001, val: 100, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 200, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 300, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 100 },
+              { millis: 1262304002789, val: 200 },
+              { millis: 1262304002789, val: 300 },
             ],
           },
         ],
@@ -245,9 +245,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 1, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ];
@@ -256,9 +256,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -267,9 +267,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -478,7 +478,7 @@ describe('Archiverappliance Functions', () => {
       const pvdata = [
         {
           meta: { name: pvname, PREC: '0' },
-          data: [{ secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 }],
+          data: [{ millis: 1262304001456, val: 0 }],
         },
       ];
 
@@ -521,9 +521,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 1, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ];
@@ -532,9 +532,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -543,9 +543,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -592,9 +592,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 3, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
+              { millis: 1262304002789, val: 3 },
             ],
           },
         ];
@@ -603,9 +603,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -614,9 +614,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -663,9 +663,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 3, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
+              { millis: 1262304002789, val: 3 },
             ],
           },
         ];
@@ -674,9 +674,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -685,9 +685,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -734,9 +734,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 3, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
+              { millis: 1262304002789, val: 3 },
             ],
           },
         ];
@@ -745,9 +745,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -756,9 +756,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 0, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 0 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -805,9 +805,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 3, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
+              { millis: 1262304002789, val: 3 },
             ],
           },
         ];
@@ -816,9 +816,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 3, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 4, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 5, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 3 },
+              { millis: 1262304002789, val: 4 },
+              { millis: 1262304002789, val: 5 },
             ],
           },
         ];
@@ -827,9 +827,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: -10, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 0, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: -10 },
+              { millis: 1262304002789, val: 0 },
+              { millis: 1262304002789, val: 0 },
             ],
           },
         ];
@@ -876,9 +876,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 3, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
+              { millis: 1262304002789, val: 3 },
             ],
           },
         ];
@@ -887,9 +887,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: -6, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 7, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 8, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: -6 },
+              { millis: 1262304002789, val: 7 },
+              { millis: 1262304002789, val: 8 },
             ],
           },
         ];
@@ -898,9 +898,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: pvname, PREC: '0' },
             data: [
-              { secs: 1262304001, val: -5, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 10, nanos: 789000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 10, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304001456, val: -5 },
+              { millis: 1262304002789, val: 10 },
+              { millis: 1262304002789, val: 10 },
             ],
           },
         ];
@@ -985,9 +985,9 @@ describe('Archiverappliance Functions', () => {
           {
             meta: { name: 'PV', PREC: '0' },
             data: [
-              { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-              { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-              { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+              { millis: 1262304000123, val: 0 },
+              { millis: 1262304001456, val: 1 },
+              { millis: 1262304002789, val: 2 },
             ],
           },
         ],

--- a/src/specs/datasource.test.ts
+++ b/src/specs/datasource.test.ts
@@ -29,9 +29,9 @@ function createDefaultResponse() {
       {
         meta: { name: 'PV', PREC: '0' },
         data: [
-          { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-          { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-          { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+          { millis: 1262304000123, val: 0 },
+          { millis: 1262304001456, val: 1 },
+          { millis: 1262304002789, val: 2 },
         ],
       },
     ],
@@ -94,7 +94,7 @@ describe('Archiverappliance Datasource', () => {
 
       ds.buildUrls(target).then((url: any) => {
         expect(url[0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -117,10 +117,10 @@ describe('Archiverappliance Datasource', () => {
 
       ds.buildUrls(target).then((url: any) => {
         expect(url[0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[1]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV2)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV2)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -144,10 +144,10 @@ describe('Archiverappliance Datasource', () => {
 
       ds.buildUrls(target).then((url: any) => {
         expect(url[0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[1]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV2)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV2)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -208,7 +208,7 @@ describe('Archiverappliance Datasource', () => {
 
       ds.buildUrls(target).then((url: any) => {
         expect(url[0]).toBe(
-          'url_header:/data/getData.json?pv=mean_100(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_100(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -226,22 +226,22 @@ describe('Archiverappliance Datasource', () => {
       ds.buildUrls(target).then((url: any) => {
         expect(url).toHaveLength(6);
         expect(url[0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVA%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVA%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[1]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVA%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVA%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[2]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVB%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVB%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[3]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVB%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVB%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[4]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVC%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVC%3A1%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(url[5]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PVC%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PVC%3A2%3Atest)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -282,22 +282,22 @@ describe('Archiverappliance Datasource', () => {
       Promise.all(urlProcs).then(urls => {
         expect(urls).toHaveLength(6);
         expect(urls[0][0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV1)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(urls[1][0]).toBe(
-          'url_header:/data/getData.json?pv=PV2&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=PV2&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(urls[2][0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV3)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV3)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(urls[3][0]).toBe(
-          'url_header:/data/getData.json?pv=mean_9(PV4)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=mean_9(PV4)&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(urls[4][0]).toBe(
-          'url_header:/data/getData.json?pv=PV5&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=PV5&from=2010-01-01T00:00:00.000Z&to=2010-01-01T00:00:30.000Z'
         );
         expect(urls[5][0]).toBe(
-          'url_header:/data/getData.json?pv=PV6&from=2010-01-01T00:00:30.000Z&to=2010-01-01T00:00:30.000Z'
+          'url_header:/data/getData.qw?pv=PV6&from=2010-01-01T00:00:30.000Z&to=2010-01-01T00:00:30.000Z'
         );
         done();
       });
@@ -366,9 +366,9 @@ describe('Archiverappliance Datasource', () => {
             {
               meta: { name: 'PV', PREC: '0' },
               data: [
-                { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-                { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-                { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+                { millis: 1262304000123, val: 0 },
+                { millis: 1262304001456, val: 1 },
+                { millis: 1262304002789, val: 2 },
               ],
             },
           ],
@@ -401,7 +401,7 @@ describe('Archiverappliance Datasource', () => {
 
     it('should return the server results with alias', done => {
       datasourceRequestMock.mockImplementation(request => {
-        const pv = request.url.slice(33, 36);
+        const pv = request.url.slice(31, 34);
         Promise.resolve({
           status: 'success',
           data: { data: ['value1', 'value2', 'value3'] },
@@ -494,9 +494,9 @@ describe('Archiverappliance Datasource', () => {
             {
               meta: { name: 'PV', PREC: '0' },
               data: [
-                { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-                { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-                { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+                { millis: 1262304000123, val: 0 },
+                { millis: 1262304001456, val: 1 },
+                { millis: 1262304002789, val: 2 },
               ],
             },
           ],
@@ -530,9 +530,9 @@ describe('Archiverappliance Datasource', () => {
             {
               meta: { name: 'PV', PREC: '0' },
               data: [
-                { secs: 1262304000, val: 0, nanos: 123000000, severity: 0, status: 0 },
-                { secs: 1262304001, val: 1, nanos: 456000000, severity: 0, status: 0 },
-                { secs: 1262304002, val: 2, nanos: 789000000, severity: 0, status: 0 },
+                { millis: 1262304000123, val: 0 },
+                { millis: 1262304001456, val: 1 },
+                { millis: 1262304002789, val: 2 },
               ],
             },
           ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,8 +36,8 @@ export interface TargetQuery {
 export interface AADataQueryResponse {
   data: {
     data: {
-      meta: { name: string; PREC: string };
-      data: [{ secs: number; val: number; nanos: number; severity: number; status: number }];
+      meta: { name: string; waveform: boolean; PREC: string };
+      data: [{ millis: number; val: number | number[] | string | string[] }];
     };
   };
   status: number;


### PR DESCRIPTION
This PR changes retrieving data format from `json` to `qw`.

`qw` format has timestamp as milli seconds while `json` format has timestamp with secs and nanos.
`qw` format allows to remove conversion from secs and nanos to milli seconds.