### PR TITLE
Add Array to Scalar functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "react-test-renderer": "16.13.1"
   },
   "dependencies": {
+    "@types/mathjs": "^6.0.7",
     "@types/react-autosuggest": "^10.0.0",
+    "mathjs": "^7.5.1",
     "react-autosuggest": "^10.0.2"
   },
   "homepage": "https://github.com/sasaki77/archiverappliance-datasource#readme"

--- a/src/aafunc.ts
+++ b/src/aafunc.ts
@@ -5,6 +5,7 @@ import { MutableDataFrame } from '@grafana/data';
 const funcIndex: { [key: string]: FuncDef } = {};
 const categories: { [key: string]: FuncDef[] } = {
   Transform: [],
+  'Array to Scalar': [],
   'Filter Series': [],
   Sort: [],
   Options: [],
@@ -49,6 +50,29 @@ addFuncDef({
 addFuncDef({
   name: 'fluctuation',
   category: 'Transform',
+  params: [],
+  defaultParams: [],
+});
+
+// Array to Scalar
+
+addFuncDef({
+  name: 'toScalarByAvg',
+  category: 'Array to Scalar',
+  params: [],
+  defaultParams: [],
+});
+
+addFuncDef({
+  name: 'toScalarByMax',
+  category: 'Array to Scalar',
+  params: [],
+  defaultParams: [],
+});
+
+addFuncDef({
+  name: 'toScalarByMin',
+  category: 'Array to Scalar',
   params: [],
   defaultParams: [],
 });

--- a/src/aafunc.ts
+++ b/src/aafunc.ts
@@ -115,6 +115,27 @@ addFuncDef({
   defaultParams: [],
 });
 
+addFuncDef({
+  name: 'toScalarBySum',
+  category: 'Array to Scalar',
+  params: [],
+  defaultParams: [],
+});
+
+addFuncDef({
+  name: 'toScalarByMed',
+  category: 'Array to Scalar',
+  params: [],
+  defaultParams: [],
+});
+
+addFuncDef({
+  name: 'toScalarByStd',
+  category: 'Array to Scalar',
+  params: [],
+  defaultParams: [],
+});
+
 // Filter Series
 
 addFuncDef({

--- a/src/components/FunctionElem.test.tsx
+++ b/src/components/FunctionElem.test.tsx
@@ -24,7 +24,6 @@ const setup = (propOverrides?: object) => {
         ],
       },
       params: ['5', 'avg'],
-      text: 'top(5, avg)',
     },
     index: 1,
     onChange: jest.fn(),

--- a/src/components/FunctionParams.test.tsx
+++ b/src/components/FunctionParams.test.tsx
@@ -24,7 +24,6 @@ const setup = (propOverrides?: object) => {
         ],
       },
       params: ['5', 'avg'],
-      text: 'top(5, avg)',
     },
     index: 1,
     onChange: jest.fn(),

--- a/src/components/Functions.tsx
+++ b/src/components/Functions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { InlineFormLabel } from '@grafana/ui';
-import { createFuncInstance } from '../aafunc';
+import { createFuncDescriptor } from '../aafunc';
 import { FuncDef, FunctionDescriptor } from '../types';
 
 import { FunctionElem } from './FunctionElem';
@@ -27,7 +27,7 @@ class Functions extends React.PureComponent<FunctionsProps> {
 
   addFunction = (funcDef: FuncDef) => {
     const { onChange, onRunQuery } = this.props;
-    const newFunc = createFuncInstance(funcDef, funcDef.defaultParams);
+    const newFunc = createFuncDescriptor(funcDef, funcDef.defaultParams);
     const newFuncs = [...this.props.funcs];
     newFuncs.push(newFunc);
     onChange(newFuncs);

--- a/src/components/__snapshots__/FunctionAdd.test.tsx.snap
+++ b/src/components/__snapshots__/FunctionAdd.test.tsx.snap
@@ -90,6 +90,33 @@ exports[`Render should render component 1`] = `
               "params": Array [],
             },
           },
+          Object {
+            "label": "toScalarBySum",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarBySum",
+              "params": Array [],
+            },
+          },
+          Object {
+            "label": "toScalarByMed",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarByMed",
+              "params": Array [],
+            },
+          },
+          Object {
+            "label": "toScalarByStd",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarByStd",
+              "params": Array [],
+            },
+          },
         ],
         "label": "Array to Scalar",
         "value": "Array to Scalar",

--- a/src/components/__snapshots__/FunctionAdd.test.tsx.snap
+++ b/src/components/__snapshots__/FunctionAdd.test.tsx.snap
@@ -64,6 +64,39 @@ exports[`Render should render component 1`] = `
       Object {
         "children": Array [
           Object {
+            "label": "toScalarByAvg",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarByAvg",
+              "params": Array [],
+            },
+          },
+          Object {
+            "label": "toScalarByMax",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarByMax",
+              "params": Array [],
+            },
+          },
+          Object {
+            "label": "toScalarByMin",
+            "value": Object {
+              "category": "Array to Scalar",
+              "defaultParams": Array [],
+              "name": "toScalarByMin",
+              "params": Array [],
+            },
+          },
+        ],
+        "label": "Array to Scalar",
+        "value": "Array to Scalar",
+      },
+      Object {
+        "children": Array [
+          Object {
             "label": "top",
             "value": Object {
               "category": "Filter Series",

--- a/src/components/__snapshots__/FunctionElem.test.tsx.snap
+++ b/src/components/__snapshots__/FunctionElem.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`Render should render component 1`] = `
           "5",
           "avg",
         ],
-        "text": "top(5, avg)",
       }
     }
     index={1}
@@ -81,7 +80,6 @@ exports[`Render should render component 1`] = `
           "5",
           "avg",
         ],
-        "text": "top(5, avg)",
       }
     }
     index={1}

--- a/src/dataProcessor.ts
+++ b/src/dataProcessor.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { MutableDataFrame, ArrayVector, getFieldDisplayName } from '@grafana/data';
+import * as math from 'mathjs';
 
 // Transform
 
@@ -185,6 +186,9 @@ const arrayFunctions: { [key: string]: { func: any; label: string } } = {
   toScalarByAvg: { func: datapointsAvg, label: 'avg' },
   toScalarByMax: { func: datapointsMax, label: 'max' },
   toScalarByMin: { func: datapointsMin, label: 'min' },
+  toScalarBySum: { func: datapointsSum, label: 'sum' },
+  toScalarByMed: { func: math.median, label: 'median' },
+  toScalarByStd: { func: math.std, label: 'std' },
 };
 
 export { functions as seriesFunctions, arrayFunctions };

--- a/src/dataProcessor.ts
+++ b/src/dataProcessor.ts
@@ -90,21 +90,19 @@ function exclude(pattern: string, dataFrames: MutableDataFrame[]) {
 // [Support Funcs] Datapoints aggregation functions
 
 function datapointsAvg(values: number[]) {
-  return _.meanBy(values, value => value);
+  return _.mean(values);
 }
 
 function datapointsMin(values: number[]) {
-  const minPoint = _.minBy(values, value => value);
-  return minPoint;
+  return _.min(values);
 }
 
 function datapointsMax(values: number[]) {
-  const maxPoint = _.maxBy(values, value => value);
-  return maxPoint;
+  return _.max(values);
 }
 
 function datapointsSum(values: number[]) {
-  return _.sumBy(values, value => value);
+  return _.sum(values);
 }
 
 function datapointsAbsMin(values: number[]) {
@@ -183,8 +181,10 @@ const functions = {
   sortByAbsMin: _.partial(sortByAggFuncs, 'absoluteMin'),
 };
 
-export default {
-  get aaFunctions() {
-    return functions;
-  },
+const arrayFunctions: { [key: string]: { func: any; label: string } } = {
+  toScalarByAvg: { func: datapointsAvg, label: 'avg' },
+  toScalarByMax: { func: datapointsMax, label: 'max' },
+  toScalarByMin: { func: datapointsMin, label: 'min' },
 };
+
+export { functions as seriesFunctions, arrayFunctions };

--- a/src/specs/aafunc.test.ts
+++ b/src/specs/aafunc.test.ts
@@ -261,6 +261,9 @@ describe('Archiverappliance Functions', () => {
             aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByAvg'), []),
             aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByMax'), []),
             aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByMin'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarBySum'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByMed'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByStd'), []),
           ],
         },
       ],
@@ -269,42 +272,72 @@ describe('Archiverappliance Functions', () => {
     } as unknown) as DataQueryRequest<AAQuery>;
 
     ds.query(query).then((result: any) => {
-      expect(result.data).toHaveLength(3);
+      expect(result.data).toHaveLength(6);
       const dataFrameAvg: MutableDataFrame = result.data[0];
       const dataFrameMax: MutableDataFrame = result.data[1];
       const dataFrameMin: MutableDataFrame = result.data[2];
+      const dataFrameSum: MutableDataFrame = result.data[3];
+      const dataFrameMed: MutableDataFrame = result.data[4];
+      const dataFrameStd: MutableDataFrame = result.data[5];
 
       const seriesNameAvg = dataFrameAvg.name;
       const seriesNameMax = dataFrameMax.name;
       const seriesNameMin = dataFrameMin.name;
+      const seriesNameSum = dataFrameSum.name;
+      const seriesNameMed = dataFrameMed.name;
+      const seriesNameStd = dataFrameStd.name;
       expect(seriesNameAvg).toBe('header:PV1');
       expect(seriesNameMax).toBe('header:PV1');
       expect(seriesNameMin).toBe('header:PV1');
+      expect(seriesNameSum).toBe('header:PV1');
+      expect(seriesNameMed).toBe('header:PV1');
+      expect(seriesNameStd).toBe('header:PV1');
 
       const valArrayAvg = dataFrameAvg.fields[1].values.toArray();
       const valArrayMax = dataFrameMax.fields[1].values.toArray();
       const valArrayMin = dataFrameMin.fields[1].values.toArray();
+      const valArraySum = dataFrameSum.fields[1].values.toArray();
+      const valArrayMed = dataFrameMed.fields[1].values.toArray();
+      const valArrayStd = dataFrameStd.fields[1].values.toArray();
 
       expect(valArrayAvg).toHaveLength(4);
       expect(valArrayMax).toHaveLength(4);
       expect(valArrayMin).toHaveLength(4);
+      expect(valArraySum).toHaveLength(4);
+      expect(valArrayMed).toHaveLength(4);
+      expect(valArrayStd).toHaveLength(4);
       expect(valArrayAvg[0]).toBe(2);
       expect(valArrayMax[0]).toBe(3);
       expect(valArrayMin[0]).toBe(1);
+      expect(valArraySum[0]).toBe(6);
+      expect(valArrayMed[0]).toBe(2);
+      expect(valArrayStd[0]).toBe(1);
 
       const nameAvg = getFieldDisplayName(dataFrameAvg.fields[1], dataFrameAvg);
       const nameMax = getFieldDisplayName(dataFrameMax.fields[1], dataFrameMax);
       const nameMin = getFieldDisplayName(dataFrameMin.fields[1], dataFrameMin);
+      const nameSum = getFieldDisplayName(dataFrameSum.fields[1], dataFrameSum);
+      const nameMed = getFieldDisplayName(dataFrameMed.fields[1], dataFrameMed);
+      const nameStd = getFieldDisplayName(dataFrameStd.fields[1], dataFrameStd);
       expect(nameAvg).toBe('header:PV1 (avg)');
       expect(nameMax).toBe('header:PV1 (max)');
       expect(nameMin).toBe('header:PV1 (min)');
+      expect(nameSum).toBe('header:PV1 (sum)');
+      expect(nameMed).toBe('header:PV1 (median)');
+      expect(nameStd).toBe('header:PV1 (std)');
 
       const timesArrayAvg = dataFrameAvg.fields[0].values.toArray();
       const timesArrayMax = dataFrameMax.fields[0].values.toArray();
       const timesArrayMin = dataFrameMin.fields[0].values.toArray();
+      const timesArraySum = dataFrameSum.fields[0].values.toArray();
+      const timesArrayMed = dataFrameMed.fields[0].values.toArray();
+      const timesArrayStd = dataFrameStd.fields[0].values.toArray();
       expect(timesArrayAvg[0]).toBe(1262304000123);
       expect(timesArrayMax[0]).toBe(1262304000123);
       expect(timesArrayMin[0]).toBe(1262304000123);
+      expect(timesArraySum[0]).toBe(1262304000123);
+      expect(timesArrayMed[0]).toBe(1262304000123);
+      expect(timesArrayStd[0]).toBe(1262304000123);
 
       done();
     });

--- a/src/specs/aafunc.test.ts
+++ b/src/specs/aafunc.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@grafana/data';
 import { DataSource } from '../DataSource';
 import * as aafunc from '../aafunc';
-import dataProcessor from '../dataProcessor';
+import { seriesFunctions } from '../dataProcessor';
 import { AAQuery, AADataSourceOptions } from '../types';
 
 const datasourceRequestMock = jest.fn().mockResolvedValue(createDefaultResponse());
@@ -75,7 +75,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('scale'), ['100'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('scale'), ['100'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -121,7 +121,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('offset'), ['100'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('offset'), ['100'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -167,7 +167,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('delta'), [])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('delta'), [])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -212,7 +212,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('fluctuation'), [])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('fluctuation'), [])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -258,9 +258,9 @@ describe('Archiverappliance Functions', () => {
           target: 'header:PV1',
           refId: 'A',
           functions: [
-            aafunc.createFuncInstance(aafunc.getFuncDef('toScalarByAvg'), []),
-            aafunc.createFuncInstance(aafunc.getFuncDef('toScalarByMax'), []),
-            aafunc.createFuncInstance(aafunc.getFuncDef('toScalarByMin'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByAvg'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByMax'), []),
+            aafunc.createFuncDescriptor(aafunc.getFuncDef('toScalarByMin'), []),
           ],
         },
       ],
@@ -360,7 +360,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('top'), ['2', 'avg'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('top'), ['2', 'avg'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -440,8 +440,8 @@ describe('Archiverappliance Functions', () => {
         })
     );
 
-    const topFunction = dataProcessor.aaFunctions.top;
-    const bottomFunction = dataProcessor.aaFunctions.bottom;
+    const topFunction = seriesFunctions.top;
+    const bottomFunction = seriesFunctions.bottom;
 
     const minTopData = topFunction(3, 'min', timeseriesData);
     const maxTopData = topFunction(1, 'max', timeseriesData);
@@ -567,7 +567,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PVA|PVB)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('exclude'), ['PV[0-9]'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('exclude'), ['PV[0-9]'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -636,7 +636,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByMax'), ['desc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByMax'), ['desc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -707,7 +707,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByMin'), ['asc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByMin'), ['asc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -778,7 +778,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByMin'), ['desc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByMin'), ['desc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -849,7 +849,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByMin'), ['asc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByMin'), ['asc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -920,7 +920,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByAbsMax'), ['desc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByAbsMax'), ['desc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -991,7 +991,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: '(PV1|PV2|PV3)',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('sortByAbsMax'), ['desc'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('sortByAbsMax'), ['desc'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -1018,7 +1018,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('maxNumPVs'), ['1000'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('maxNumPVs'), ['1000'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },
@@ -1038,7 +1038,7 @@ describe('Archiverappliance Functions', () => {
         {
           target: 'PV1',
           refId: 'A',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('disableAutoRaw'), ['true'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('disableAutoRaw'), ['true'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-01T00:00:30.000Z') },
@@ -1074,7 +1074,7 @@ describe('Archiverappliance Functions', () => {
           target: 'PV',
           refId: 'A',
           operator: 'raw',
-          functions: [aafunc.createFuncInstance(aafunc.getFuncDef('disableExtrapol'), ['true'])],
+          functions: [aafunc.createFuncDescriptor(aafunc.getFuncDef('disableExtrapol'), ['true'])],
         },
       ],
       range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-02T00:00:00.000Z') },

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,6 @@ export interface FuncDef {
 }
 
 export interface FunctionDescriptor {
-  text: string;
   params: string[];
   def: FuncDef;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,16 @@ export interface AADataQueryData {
   data: [{ millis: number; val: number | number[] | string | string[] }];
 }
 
+export interface AADataQueryDataScalar {
+  meta: { name: string; waveform: boolean; PREC: string };
+  data: [{ millis: number; val: number | string }];
+}
+
+export interface AADataQueryDataNumberArray {
+  meta: { name: string; waveform: boolean; PREC: string };
+  data: [{ millis: number; val: number[] }];
+}
+
 export interface AADataQueryResponse {
   data: {
     data: AADataQueryData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,6 +1776,13 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.162.tgz#65d78c397e0d883f44afbf1f7ba9867022411470"
   integrity sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
 
+"@types/mathjs@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@types/mathjs/-/mathjs-6.0.7.tgz#89299b8e0dd369c970ee8f477ba2cd2527c56cd0"
+  integrity sha512-UPpG34wVjlr8uSijJ747q0SmC459t294xm/3Ed8GAnqM/I2K786WgCLQ4BO4lIsM07Gj1UhO7x0n0TSfqO0DNQ==
+  dependencies:
+    decimal.js "^10.0.0"
+
 "@types/mime@*":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.2.tgz#857a118d8634c84bba7ae14088e4508490cd5da5"
@@ -3680,6 +3687,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+complex.js@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.11.tgz#09a873fbf15ffd8c18c9c2201ccef425c32b8bf1"
+  integrity sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw==
+
 component-classes@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
@@ -4518,6 +4530,11 @@ decamelize@^1.0.0, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js@^10.0.0, decimal.js@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -5060,6 +5077,11 @@ es6-templates@^0.2.3:
   dependencies:
     recast "~0.11.12"
     through "~2.3.6"
+
+escape-latex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
+  integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
 
 escape-string-regexp@2.0.0:
   version "2.0.0"
@@ -5731,6 +5753,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fraction.js@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.12.tgz#0526d47c65a5fb4854df78bc77f7bec708d7b8c3"
+  integrity sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -6916,6 +6943,11 @@ istanbul-reports@^2.2.6:
   dependencies:
     html-escaper "^2.0.0"
 
+javascript-natural-sort@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
+
 jest-canvas-mock@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.1.2.tgz#0d16c9f91534f773fd132fc289f2e6b6db8faa28"
@@ -7868,6 +7900,20 @@ material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
+
+mathjs@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-7.5.1.tgz#eb125295310a99ddcaf6145c47b09aab36e48274"
+  integrity sha512-H2q/Dq0qxBLMw+G84SSXmGqo/znihuxviGgAQwAcyeFLwK2HksvSGNx4f3dllZF51bWOnu2op60VZxH2Sb51Pw==
+  dependencies:
+    complex.js "^2.0.11"
+    decimal.js "^10.2.1"
+    escape-latex "^1.2.0"
+    fraction.js "^4.0.12"
+    javascript-natural-sort "^0.7.1"
+    seed-random "^2.2.0"
+    tiny-emitter "^2.1.0"
+    typed-function "^2.0.0"
 
 md5-file@^4.0.0:
   version "4.0.0"
@@ -11029,6 +11075,11 @@ section-iterator@^2.0.0:
   resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
   integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
 
+seed-random@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
+  integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
+
 selection-is-backward@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/selection-is-backward/-/selection-is-backward-1.0.0.tgz#97a54633188a511aba6419fc5c1fa91b467e6be1"
@@ -11917,6 +11968,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tiny-invariant@^1.0.1, tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
@@ -12142,6 +12198,11 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
   integrity sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI=
+
+typed-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.0.0.tgz#15ab3825845138a8b1113bd89e60cd6a435739e8"
+  integrity sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==
 
 typed-styles@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
This PR adds `Array to Scalar` functions.

`Array to Scalar` functions allows to transform array data into scalar data with some method.

This PR includes the functions as below.

-  toScalarByAvg
-  toScalarByMax
-  toScalarByMin
-  toScalarBySum
-  toScalarByMed
-  toScalarByStd