### PR TITLE
fix: Fix Function parm width during focusing on

### DIFF
--- a/src/components/FunctionParam.tsx
+++ b/src/components/FunctionParam.tsx
@@ -88,11 +88,12 @@ class FunctionParam extends React.PureComponent<FunctionParamProps, State> {
   };
 
   calcInputWidth = (focused: boolean, param: string, placeholder: string) => {
+    const paramLength = param.length;
+
     if (focused) {
-      return '90px';
+      return paramLength < 13 ? `13ch` : `${paramLength + 2}ch`;
     }
 
-    const paramLength = param.length;
     return paramLength < 1 ? `${placeholder.length}ch` : `${paramLength}ch`;
   };
 


### PR DESCRIPTION
This PR fixes function parameter width during focusing on it.

The width is dynamically changed when the parameter length is more than default parameter width.