### PR TITLE
Automate documentation building on tags 

### DIFF
--- a/.github/workflows/build-publish-docs.yml
+++ b/.github/workflows/build-publish-docs.yml
@@ -1,5 +1,6 @@
 name: build-publish-docs.yml
 on:
+  workflow_dispatch:
   push:
     paths:
     - 'docs/**'

--- a/.github/workflows/build-publish-docs.yml
+++ b/.github/workflows/build-publish-docs.yml
@@ -7,6 +7,10 @@ jobs:
   build-publish-docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Github repository
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-publish-docs.yml
+++ b/.github/workflows/build-publish-docs.yml
@@ -1,0 +1,27 @@
+name: build-publish-docs.yml
+on:
+  push:
+    paths:
+    - 'docs/**'
+jobs:
+  build-publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Python Dependencies 
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
+      - name: Build Sphinx Documentation
+        run: | 
+          cd docs
+          make html
+      - name: Deploy Documentation to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+

--- a/.github/workflows/build-publish-docs.yml
+++ b/.github/workflows/build-publish-docs.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-publish-docs:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Github repository
         uses: actions/checkout@v2

--- a/.github/workflows/build-publish-docs.yml
+++ b/.github/workflows/build-publish-docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-publish-docs:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout Github repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,63 +18,63 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      # - name: Setup NodeJS environment
-      #   uses: actions/setup-node@v1
-      #   with:
-      #     node-version: ${{ matrix.node }}
-      # - name: Setup Go environment 
-      #   uses: actions/setup-go@v2
-      # - name: Run Go tests using Mage
-      #   uses: magefile/mage-action@v1
-      #   with:
-      #     version: latest
-      #     args: vtest
-      # - name: Build backend
-      #   uses: magefile/mage-action@v1
-      #   with:
-      #     version: latest
-      #     args: -v buildAll
-      # - name: Install frontend tools
-      #   run: |
-      #     npm install -g yarn
-      #     yarn install
-      # - name: List all Yarn packages
-      #   run: | 
-      #     yarn list
-      # - name: Build frontend
-      #   run: |
-      #     yarn build
-      # - name: Create release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ github.ref }}
-      #     body: |
-      #       This release as been been automatically generated.
-      #     draft: false
-      #     prerelease: true
-      # - name: Prepare Release
-      #   env:
-      #     ZIP_NAME: ${{ env.zip-name }}
-      #   run: |
-      #     REPO_DIRECTORY=${PWD##*/}
-      #     ls
-      #     pushd ../
-      #     zip -r $REPO_DIRECTORY/$ZIP_NAME.zip $REPO_DIRECTORY -x @$REPO_DIRECTORY/exclude.txt
-      #     popd
-      # - name: Upload Release Asset
-      #   id: upload-release-asset 
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-      #     asset_path: ./${{ env.zip-name }}.zip
-      #     asset_name: ${{ env.zip-name }}.zip
-      #     asset_content_type: application/zip
+      - name: Setup NodeJS environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Setup Go environment 
+        uses: actions/setup-go@v2
+      - name: Run Go tests using Mage
+        uses: magefile/mage-action@v1
+        with:
+          version: latest
+          args: vtest
+      - name: Build backend
+        uses: magefile/mage-action@v1
+        with:
+          version: latest
+          args: -v buildAll
+      - name: Install frontend tools
+        run: |
+          npm install -g yarn
+          yarn install
+      - name: List all Yarn packages
+        run: | 
+          yarn list
+      - name: Build frontend
+        run: |
+          yarn build
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            This release as been been automatically generated.
+          draft: false
+          prerelease: true
+      - name: Prepare Release
+        env:
+          ZIP_NAME: ${{ env.zip-name }}
+        run: |
+          REPO_DIRECTORY=${PWD##*/}
+          ls
+          pushd ../
+          zip -r $REPO_DIRECTORY/$ZIP_NAME.zip $REPO_DIRECTORY -x @$REPO_DIRECTORY/exclude.txt
+          popd
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./${{ env.zip-name }}.zip
+          asset_name: ${{ env.zip-name }}.zip
+          asset_content_type: application/zip
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -75,3 +75,20 @@ jobs:
           asset_path: ./${{ env.zip-name }}.zip
           asset_name: ${{ env.zip-name }}.zip
           asset_content_type: application/zip
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python Dependencies 
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
+      - name: Build Sphinx Documentation
+        run: | 
+          cd docs
+          make html
+      - name: Deploy Documentation to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,63 +18,63 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Setup NodeJS environment
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Setup Go environment 
-        uses: actions/setup-go@v2
-      - name: Run Go tests using Mage
-        uses: magefile/mage-action@v1
-        with:
-          version: latest
-          args: vtest
-      - name: Build backend
-        uses: magefile/mage-action@v1
-        with:
-          version: latest
-          args: -v buildAll
-      - name: Install frontend tools
-        run: |
-          npm install -g yarn
-          yarn install
-      - name: List all Yarn packages
-        run: | 
-          yarn list
-      - name: Build frontend
-        run: |
-          yarn build
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            This release as been been automatically generated.
-          draft: false
-          prerelease: true
-      - name: Prepare Release
-        env:
-          ZIP_NAME: ${{ env.zip-name }}
-        run: |
-          REPO_DIRECTORY=${PWD##*/}
-          ls
-          pushd ../
-          zip -r $REPO_DIRECTORY/$ZIP_NAME.zip $REPO_DIRECTORY -x @$REPO_DIRECTORY/exclude.txt
-          popd
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./${{ env.zip-name }}.zip
-          asset_name: ${{ env.zip-name }}.zip
-          asset_content_type: application/zip
+      # - name: Setup NodeJS environment
+      #   uses: actions/setup-node@v1
+      #   with:
+      #     node-version: ${{ matrix.node }}
+      # - name: Setup Go environment 
+      #   uses: actions/setup-go@v2
+      # - name: Run Go tests using Mage
+      #   uses: magefile/mage-action@v1
+      #   with:
+      #     version: latest
+      #     args: vtest
+      # - name: Build backend
+      #   uses: magefile/mage-action@v1
+      #   with:
+      #     version: latest
+      #     args: -v buildAll
+      # - name: Install frontend tools
+      #   run: |
+      #     npm install -g yarn
+      #     yarn install
+      # - name: List all Yarn packages
+      #   run: | 
+      #     yarn list
+      # - name: Build frontend
+      #   run: |
+      #     yarn build
+      # - name: Create release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ github.ref }}
+      #     body: |
+      #       This release as been been automatically generated.
+      #     draft: false
+      #     prerelease: true
+      # - name: Prepare Release
+      #   env:
+      #     ZIP_NAME: ${{ env.zip-name }}
+      #   run: |
+      #     REPO_DIRECTORY=${PWD##*/}
+      #     ls
+      #     pushd ../
+      #     zip -r $REPO_DIRECTORY/$ZIP_NAME.zip $REPO_DIRECTORY -x @$REPO_DIRECTORY/exclude.txt
+      #     popd
+      # - name: Upload Release Asset
+      #   id: upload-release-asset 
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+      #     asset_path: ./${{ env.zip-name }}.zip
+      #     asset_name: ${{ env.zip-name }}.zip
+      #     asset_content_type: application/zip
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
@@ -91,4 +91,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build
+          publish_dir: ./docs/_build/html

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -75,20 +75,3 @@ jobs:
           asset_path: ./${{ env.zip-name }}.zip
           asset_name: ${{ env.zip-name }}.zip
           asset_content_type: application/zip
-      - name: Set up Python environment
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install Python Dependencies 
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
-      - name: Build Sphinx Documentation
-        run: | 
-          cd docs
-          make html
-      - name: Deploy Documentation to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
       - name: Install Python Dependencies 
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ grafana
 
 # Production files
 /dist
+
+#OSX files
+*.DS_store

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx>=3.5.1
+recommonmark>=0.7.1
+sphinx-rtd-theme>=0.5.1
+sphinx-markdown-tables>=0.0.15


### PR DESCRIPTION
This PR adds documentation generation and posting to the `publish-release.yml` CI script. Documentation will be pushed to the `gh-pages` branch whenever a new tag is pushed to the GitHub repository. 

Discussion is welcome. 