### PR TITLE
BUG: properly name values

### DIFF
--- a/pkg/archiver-interface.go
+++ b/pkg/archiver-interface.go
@@ -100,7 +100,7 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
     }
 
 
-    // for each query response, compile the data into response.Framse
+    // for each query response, compile the data into response.Frames
     for _, singleResponse := range responseData {
         // create data frame response
         frame := data.NewFrame("response")

--- a/pkg/archiver-interface.go
+++ b/pkg/archiver-interface.go
@@ -61,7 +61,6 @@ func (td *ArchiverDatasource) CheckHealth(ctx context.Context, req *backend.Chec
 }
 
 func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery, pluginctx backend.PluginContext) backend.DataResponse {
-
     // Unmarshal the json into our queryModel
     var qm ArchiverQueryModel
 
@@ -113,7 +112,7 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
 
         // add values 
         frame.Fields = append(frame.Fields, 
-            data.NewField("values", nil, singleResponse.Values),
+            data.NewField(singleResponse.Name, nil, singleResponse.Values),
         )
 
         // add the frames to the response

--- a/pkg/archiver-interface.go
+++ b/pkg/archiver-interface.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 func newArchiverDataSource() datasource.ServeOpts {
@@ -102,18 +101,8 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
 
     // for each query response, compile the data into response.Frames
     for _, singleResponse := range responseData {
-        // create data frame response
-        frame := data.NewFrame("response")
 
-        //add the time dimension
-        frame.Fields = append(frame.Fields,
-            data.NewField("time", nil, singleResponse.Times),
-        )
-
-        // add values 
-        frame.Fields = append(frame.Fields, 
-            data.NewField(singleResponse.Name, nil, singleResponse.Values),
-        )
+        frame := FrameBuilder(singleResponse)
 
         // add the frames to the response
         response.Frames = append(response.Frames, frame)

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 type ArchiverQueryModel struct {
@@ -282,3 +283,19 @@ func IsolateBasicQuery(unparsed string) []string {
     return result
 }
 
+func FrameBuilder(singleResponse SingleData) *data.Frame {
+        // create data frame response
+        frame := data.NewFrame("response")
+
+        //add the time dimension
+        frame.Fields = append(frame.Fields,
+            data.NewField("time", nil, singleResponse.Times),
+        )
+
+        // add values 
+        frame.Fields = append(frame.Fields,
+            data.NewField(singleResponse.Name, nil, singleResponse.Values),
+        )
+
+        return frame
+}

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -294,3 +294,26 @@ func TestIsolateBasicQuery(t *testing.T) {
         })
     }
 }
+
+func TestFrameBuilder(t *testing.T) {
+    var tests = []struct{
+        sD SingleData
+        name string
+    }{
+        {
+            sD: SingleData{
+                Name: "testing_name",
+            },
+            name: "testing_name",
+        },
+    }
+    for idx, testCase := range tests {
+        testName := fmt.Sprintf("%d: %s", idx, testCase.name)
+        t.Run(testName, func(t *testing.T) {
+            result := FrameBuilder(testCase.sD)
+            if testCase.name != result.Fields[1].Name {
+                t.Errorf("got %v, want %v", result.Fields[1].Name, testCase.name)
+            }
+        })
+    }
+}


### PR DESCRIPTION
This resolves the issue in which the all plots were displayed with the name "values" when using the back end data source exclusively. 