### PR TITLE
Reduce query size

### DIFF
--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -26,6 +26,9 @@ type ArchiverQueryModel struct {
     Operator string `json:"operator"` // ?
     Regex bool `json:"regex"` // configured by the user's setting of the "Regex" field in the panel
     Functions []FunctionDescriptorQueryModel `json:"functions"` // collection of functions to be applied to the data by the archiver
+
+    // Only appears for visualization queries
+    IntervalMs *int `json:"intervalMs,omitempty"`
     /*
         Functions is a few layers deep:
         Functions []FunctionDescriptorQueryModel contains: 
@@ -84,6 +87,9 @@ func BuildQueryUrl(target string, query backend.DataQuery, pluginctx backend.Plu
     if opErr != nil {
         log.DefaultLogger.Warn("Operator has not been properly created")
     }
+
+    log.DefaultLogger.Debug("pluginctx","pluginctx", pluginctx)
+    log.DefaultLogger.Debug("query","query", query)
 
     var targetPv string
     if len(opQuery) > 0 {

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -72,6 +72,43 @@ func TestBuildQueryUrl(t *testing.T) {
                     "alias": null,
                     "aliasPattern": null,
                     "constant":6.5, 
+                    "functions":[], 
+                    "hide":false ,
+                    "operator": null,
+                    "refId":"A" ,
+                    "regex":true ,
+                    "target":"MR1K[1,3]:BEND:PIP:1:PMON"}`),
+                MaxDataPoints:0,
+                QueryType: "",
+                RefID:"A",
+                TimeRange: backend.TimeRange{
+                    From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")), 
+                    To: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:30:41.678-08:00")),
+                },
+            },
+            pluginctx: backend.PluginContext{
+                 DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{URL: "http://localhost:3396/retrieval",},
+            },
+            qm: ArchiverQueryModel{
+                IntervalMs: InitIntPointer(2000),
+                Functions: []FunctionDescriptorQueryModel{},
+                Operator: "",
+                QueryText: "",
+                QueryType: nil,
+                RefId: "A",
+                Regex: true,
+                Target: "MR1K[1,3]:BEND:PIP:1:PMON",
+            },
+            output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=mean_2%28MR1K1%3ABEND%3APIP%3A1%3APMON%29&to=2021-01-27T14%3A30%3A41.678-08%3A00",
+        },
+        {
+            target: "MR1K1:BEND:PIP:1:PMON",
+            query: backend.DataQuery{
+                Interval: MultiReturnHelperParseDuration(time.ParseDuration("0s")),
+                JSON: json.RawMessage(`{
+                    "alias": null,
+                    "aliasPattern": null,
+                    "constant":6.5, 
                     "functions":[
                         {
                             "def":{
@@ -231,7 +268,6 @@ func TestArchiverSingleQueryParser(t *testing.T) {
             }
         })
     }
-
 }
 
 func TestBuildRegexUrl(t *testing.T) {

--- a/pkg/query-operators_test.go
+++ b/pkg/query-operators_test.go
@@ -29,6 +29,7 @@ func TestOperatorValidator(t *testing.T) {
 func TestCreateOperatorQuery(t *testing.T) {
     var tests = []struct{
         input ArchiverQueryModel
+        
         output string
     }{
         {
@@ -68,6 +69,13 @@ func TestCreateOperatorQuery(t *testing.T) {
                 Operator: "raw",
             },
             output: "",
+        },
+        {
+            input: ArchiverQueryModel{
+                IntervalMs: InitIntPointer(10000),
+                Operator: "",
+            },
+            output: "mean_10",
         },
     }
     for idx, testCase := range tests {

--- a/pkg/test_helpers.go
+++ b/pkg/test_helpers.go
@@ -24,6 +24,11 @@ func InitRawMsg(value string) *json.RawMessage{
     return &new_msg
 }
 
+func InitIntPointer(value int) *int{
+    new_int := value
+    return &new_int
+}
+
 func TimeHelper(minutes int) time.Time {
     // Shortcut for generating consistent timestamps using only a single int 
     return time.Date(2021, time.January, 10, 1, minutes, 0, 0, time.UTC)


### PR DESCRIPTION
This PR closes #36. 

Only when using the backend for visualizations, the the backed will automatically apply the mean_# operator to reduce the volume of the data sent from the archiver. The size of the binning is based upon grafana's automatic bin sizing. 