### PR TITLE
Resolves multi-variables bug

### DIFF
--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -324,7 +324,7 @@ func PermuteQuery( inputData [][]string) [][]string {
             {
                 {"a", "c"}
                 {"a", "d"}
-                {"d", "c"}
+                {"b", "c"}
                 {"b", "d"}
             }
     */

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -293,13 +293,20 @@ func IsolateBasicQuery(unparsed string) []string {
     for idx, _ := range multiPhrases {
         // Strip parenthesis
         multiPhrases[idx] = strings.Trim(multiPhrases[idx], "()")
+        // Break parsed phrases on "|"
         phraseParts = append(phraseParts, strings.Split(multiPhrases[idx], "|"))
     }
 
-    // insertionSet := PermuteQuery(phraseParts)
+    // list of all the configurations for the in-order phrases to be inserted
+    phraseCase := PermuteQuery(phraseParts)
 
+    result := make([]string, 0, len(phraseCase))
 
-    return multiPhrases
+    // for idx, _ := range phraseCase {
+
+    // }
+
+    return result
 }
 
 func PermuteQuery( inputData [][]string) [][]string {
@@ -325,6 +332,28 @@ func permuteQueryRecurse( inputData [][]string, trace []string) [][]string {
     return output
 }
 
+func SelectiveInsert( input string, idxs [][]int, inserts []string) string {
+    var builder strings.Builder
+
+    prevIdx := 0
+
+    // return a blank string if the arguments are bad
+    if len(idxs) != len(inserts) {
+        return ""
+    }
+    for idx, val := range idxs {
+        firstVal := val[0]
+        builder.WriteString(input[prevIdx:firstVal])
+        builder.WriteString(inserts[idx])
+        prevIdx = val[1]
+    }
+    if prevIdx < len(input) {
+        lastVal := len(input)
+        builder.WriteString(input[prevIdx:lastVal])
+    }
+
+    return builder.String()
+}
 
 func FrameBuilder(singleResponse SingleData) *data.Frame {
         // create data frame response

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -89,8 +89,8 @@ func BuildQueryUrl(target string, query backend.DataQuery, pluginctx backend.Plu
         log.DefaultLogger.Warn("Operator has not been properly created")
     }
 
-    log.DefaultLogger.Debug("pluginctx","pluginctx", pluginctx)
-    log.DefaultLogger.Debug("query","query", query)
+    // log.DefaultLogger.Debug("pluginctx","pluginctx", pluginctx)
+    // log.DefaultLogger.Debug("query","query", query)
 
     var targetPv string
     if len(opQuery) > 0 {

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -311,17 +311,42 @@ func IsolateBasicQuery(unparsed string) []string {
 }
 
 func PermuteQuery( inputData [][]string) [][]string {
+    /*
+        Generate all ordered permutations of the input strings to make the following operation occur: 
+
+        input:
+            {
+                {"a", "b"}
+                {"c", "d"}
+            }
+
+        output:
+            {
+                {"a", "c"}
+                {"a", "d"}
+                {"d", "c"}
+                {"b", "d"}
+            }
+    */
     return permuteQueryRecurse(inputData,[]string{}) 
 }
 
 func permuteQueryRecurse( inputData [][]string, trace []string) [][]string {
-    // If you're at the end, return
+    /* 
+        recursive method for visitng all the permutations. 
+    */
+
+    // If you've assigned a value for each phrase, just return the full sequence of phrases 
     if len(trace) == len(inputData) {
         output := make([][]string,0,1)
         output = append(output, trace)
         return output
     }
 
+    /*
+        When values aren't assigned to all phrases, begin by assigning the first unassigned value 
+        to each of the possible values and recursing on the result of that
+    */
     targetIdx := len(trace)
     output := make([][]string, 0, len(inputData[targetIdx]))
     for _, value := range inputData[targetIdx] {
@@ -334,6 +359,15 @@ func permuteQueryRecurse( inputData [][]string, trace []string) [][]string {
 }
 
 func SelectiveInsert( input string, idxs [][]int, inserts []string) string {
+    /*
+        Selectively replace portions of the input string
+
+        idxs indicates the indices which will be removed
+
+        inserts provides the new string that will be put into the input string at the place designated by idxs
+
+        idxs and inserts should have the same length and are matched with each other element-wise to support any number of substitutions
+    */
     var builder strings.Builder
 
     prevIdx := 0
@@ -342,12 +376,16 @@ func SelectiveInsert( input string, idxs [][]int, inserts []string) string {
     if len(idxs) != len(inserts) {
         return ""
     }
+
+    // At each place marked by idx, insert the corresponding new string
     for idx, val := range idxs {
         firstVal := val[0]
         builder.WriteString(input[prevIdx:firstVal])
         builder.WriteString(inserts[idx])
         prevIdx = val[1]
     }
+
+    // Handle any trailing string 
     if prevIdx < len(input) {
         lastVal := len(input)
         builder.WriteString(input[prevIdx:lastVal])

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -285,7 +285,7 @@ func IsolateBasicQuery(unparsed string) []string {
     // Identify parenthesis-bound sections
     multiPhrases := multiFinder.FindAllString(unparsed_clean, -1)
     // Locate parenthesis-bound sections
-    // phraseIdx := multiFinder.FindAllStringIndex(unparsed, -1)
+    phraseIdxs := multiFinder.FindAllStringIndex(unparsed, -1)
 
     // A list of all the possible phrases
     phraseParts := make([][]string, 0, len(multiPhrases))
@@ -302,9 +302,10 @@ func IsolateBasicQuery(unparsed string) []string {
 
     result := make([]string, 0, len(phraseCase))
 
-    // for idx, _ := range phraseCase {
-
-    // }
+    for _, phrase := range phraseCase {
+        createdString := SelectiveInsert(unparsed_clean, phraseIdxs, phrase)
+        result = append(result, createdString)
+    }
 
     return result
 }

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -315,7 +315,7 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "(this):is:1", output: []string{"this:is:1"}},
         {inputUnparsed: "before:(this)", output: []string{"before:this"}},
         {inputUnparsed: "before:(this|that):is:1", output: []string{"before:this:is:1","before:that:is:1"}},
-        {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:that:is:1","before:this:was:1","before:that:was:1"}},
+        {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:this:was:1","before:that:is:1","before:that:was:1"}},
         {inputUnparsed: "()", output: []string{""}},
     }
 
@@ -417,8 +417,6 @@ func TestSelectiveInsert(t *testing.T) {
             }
         })
     }
-
-
 }
 
 func TestFrameBuilder(t *testing.T) {

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -316,6 +316,7 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "before:(this)", output: []string{"before:this"}},
         {inputUnparsed: "before:(this|that):is:1", output: []string{"before:this:is:1","before:that:is:1"}},
         {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:that:is:1","before:this:was:1","before:that:was:1"}},
+        {inputUnparsed: "()", output: []string{""}},
     }
 
     for idx, testCase := range tests {
@@ -329,6 +330,40 @@ func TestIsolateBasicQuery(t *testing.T) {
             for idx, _ := range(testCase.output) {
                 if testCase.output[idx] != result[idx] {
                     t.Errorf("got %v, want %v", result, testCase.output)
+                }
+            }
+        })
+    }
+}
+
+func TestPermuteQuery(t *testing.T) {
+    var tests = []struct{
+        input [][]string
+        output [][]string
+    }{
+        {input: [][]string{{"a","d"},{"b","c"}},    output: [][]string{{"a", "b"},{"a", "c"},{"d", "b"},{"d", "c"}}},
+        {input: [][]string{{"a"},{"b","c"}},        output: [][]string{{"a", "b"},{"a", "c"}}},
+        {input: [][]string{{"a"},{"b"}},            output: [][]string{{"a", "b"}}},
+        {input: [][]string{{"a"}},                  output: [][]string{{"a"}}},
+        {input: [][]string{{"a", "b"}},             output: [][]string{{"a"},{"b"}}},
+        {input: [][]string{{}},                     output: [][]string{}},
+        {input: [][]string{},                       output: [][]string{{}}},
+    }
+    for idx, testCase := range tests {
+        testName := fmt.Sprintf("%d: %s, %s", idx, testCase.input, testCase.output)
+        t.Run(testName, func(t *testing.T) {
+            result := PermuteQuery(testCase.input)
+            if len(result) != len(testCase.output) {
+                t.Fatalf("Lengths differ (0th index) - Wanted: %v (%v) Got: %v (%v)", testCase.output, len(testCase.output), result, len(result))
+            }
+            for idx, _ := range(testCase.output) {
+                if len(result[idx]) != len(testCase.output[idx]) {
+                    t.Fatalf("Lengths differ (1st index) - Wanted: %v (%v) Got: %v (%v)", testCase.output[idx], len(testCase.output[idx]), result[idx], len(result[idx]))
+                }
+                for jdx, _ := range(testCase.output[idx]) {
+                    if testCase.output[idx][jdx] != result[idx][jdx] {
+                        t.Errorf("got %v, want %v at [%v][%v]", result, testCase.output, idx, jdx)
+                    }
                 }
             }
         })

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -370,6 +370,57 @@ func TestPermuteQuery(t *testing.T) {
     }
 }
 
+func TestSelectiveInsert(t *testing.T) {
+    var tests = []struct{
+        input string
+        idxs [][]int
+        inserts []string
+        output string
+    }{
+        {
+            input: "hello there",
+            idxs: [][]int{{0,5}},
+            inserts: []string{"be"},
+            output: "be there",
+        },
+        {
+            input: "hello there",
+            idxs: [][]int{{6,11}},
+            inserts: []string{"friend"},
+            output: "hello friend",
+        },
+        {
+            input: "hello there",
+            idxs: [][]int{{0,4}, {6,11}},
+            inserts: []string{"y", "what's up"},
+            output: "yo what's up",
+        },
+        {
+            input: "This won't work",
+            idxs: [][]int{{0,4}, {6,11}},
+            inserts: []string{"y"},
+            output: "",
+        },
+        // {
+        //     input: ,
+        //     idxs: ,
+        //     inserts: ,
+        //     outpu:, 
+        // },
+    }
+    for idx, testCase := range tests {
+        testName := fmt.Sprintf("%d: %s, %s", idx, testCase.input, testCase.output)
+        t.Run(testName, func(t *testing.T) {
+            result := SelectiveInsert(testCase.input, testCase.idxs, testCase.inserts)
+            if testCase.output != result {
+                t.Errorf("Incorrect output - Wanted: %v Got: %v", testCase.output, result)
+            }
+        })
+    }
+
+
+}
+
 func TestFrameBuilder(t *testing.T) {
     var tests = []struct{
         sD SingleData

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -312,6 +312,10 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "(this:is:1|this:is:2)", output: []string{"this:is:1", "this:is:2"}},
         {inputUnparsed: "(this:is:1)", output: []string{"this:is:1"}},
         {inputUnparsed: "this:is:1", output: []string{"this:is:1"}},
+        {inputUnparsed: "(this):is:1", output: []string{"this:is:1"}},
+        {inputUnparsed: "before:(this)", output: []string{"before:this"}},
+        {inputUnparsed: "before:(this|that):is:1", output: []string{"before:this:is:1","before:that:is:1"}},
+        {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:that:is:1","before:this:was:1","before:that:was:1"}},
     }
 
     for idx, testCase := range tests {


### PR DESCRIPTION
Allows PVs of the form `prefix:(var:1|var:2|...|):intermediate:(a|b|...):suffix` to work properly with the backend and alerting. 

Closes #40 