### PR TITLE
Parallel queries enhancement. 

### DIFF
--- a/pkg/archiver-functions.go
+++ b/pkg/archiver-functions.go
@@ -129,6 +129,7 @@ func (fdqm FunctionDescriptorQueryModel) ExtractParamString (target string) (str
 
 func ApplyFunctions(responseData []SingleData, qm ArchiverQueryModel) ([]SingleData, error) {
     // iterate through the list of functions
+    // This should be applied to the entirety of the single query as some functions need knowldege off the data series in order to work
     newData := responseData
     for _, fdqm := range qm.Functions {
         var err error

--- a/pkg/archiver-interface.go
+++ b/pkg/archiver-interface.go
@@ -71,7 +71,6 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
     }
 
     // make the query and compile the results into a SingleData instance
-    responseData := make([]SingleData, 0)
     targetPvList := make([]string,0)
     if qm.Regex {
         // If the user is using a regex to specify the PVs, parse and resolve the regex expression first
@@ -86,9 +85,10 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
     }
 
     // execute the individual queries
-    for _, targetPv := range targetPvList {
+    responseData := make([]SingleData, len(targetPvList))
+    for idx, targetPv := range targetPvList {
         parsedResponse, _ := ExecuteSingleQuery(targetPv, query, pluginctx, qm)
-        responseData = append(responseData, parsedResponse)
+        responseData[idx] = parsedResponse
     }
 
     // Apply Functions to the data

--- a/pkg/archiver-interface.go
+++ b/pkg/archiver-interface.go
@@ -92,7 +92,7 @@ func (td *ArchiverDatasource) query(ctx context.Context, query backend.DataQuery
 
     // For debugging
     parallel := true
-    timeoutDurationSeconds := 120 // units are seconds
+    timeoutDurationSeconds := 30 // units are seconds
 
     for _, targetPv := range targetPvList {
         if parallel {

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"encoding/json"
-	"net/http"
+    "encoding/json"
+    "net/http"
     "net/url"
-	"time"
+    "time"
     "strings"
     "strconv"
     "io/ioutil"
-
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
+    "sync"
+    
+    "github.com/grafana/grafana-plugin-sdk-go/backend"
+    "github.com/grafana/grafana-plugin-sdk-go/backend/log"
+    "github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 type ArchiverQueryModel struct {
@@ -273,6 +274,11 @@ func ExecuteSingleQuery(target string, query backend.DataQuery, pluginctx backen
     queryResponse, _ := ArchiverSingleQuery(queryUrl)
     parsedResponse, _ := ArchiverSingleQueryParser(queryResponse)
     return parsedResponse, nil
+}
+
+func SingleQueryRoutine(targetPv string, query backend.DataQuery, pluginctx backend.PluginContext, qm ArchiverQueryModel, responseData []SingleData, idx int, waitMgr *sync.WaitGroup) {
+        parsedResponse, _ := ExecuteSingleQuery(targetPv, query, pluginctx, qm)
+        responseData[idx] = parsedResponse
 }
 
 func IsolateBasicQuery(unparsed string) []string {

--- a/pkg/functions.go
+++ b/pkg/functions.go
@@ -19,6 +19,7 @@ type SingleDataOrder struct {
 }
 
 func FilterIndexer(allData []SingleData, value string) ([]float64, error) {
+    // determine a single value for each SingleData. Useful for sorting or ranking SingleData
     rank := make([]float64, len(allData))
     for idx, sData := range allData {
         data := sData.Values
@@ -98,6 +99,9 @@ func FilterIndexer(allData []SingleData, value string) ([]float64, error) {
 }
 
 func SortCore(allData []SingleData, value string, order string) ([]SingleData, error) {
+    // Sort allData
+    // The order parameter chooses whether the order of the sort is ascending or descending
+    // The value parameter determines how the rank of each SingleData entry is measured 
     newData := make([]SingleData, 0, len(allData))
     rank, idxErr  := FilterIndexer(allData, value)
     if idxErr != nil {


### PR DESCRIPTION
Addresses #37. 

This makes the queries to the Archiver execute in parallel as opposed to serially. 

Should be merged after #41. Most of the diff shown in this PR is caused by an early merge I made in order to handle some incompatibilities between the two branches. 