### PR TITLE
TST: add test for 1-length input to fluctutaion funciton

### DIFF
--- a/pkg/functions_test.go
+++ b/pkg/functions_test.go
@@ -135,6 +135,20 @@ func TestFluctuation(t *testing.T) {
                 },
             },
         },
+        {
+            inputSd: []SingleData{
+                {
+                    Times: TimeArrayHelper(0,1),
+                    Values: []float64{1},
+                },
+            },
+            output: []SingleData{
+                {
+                    Times: TimeArrayHelper(0,1),
+                    Values: []float64{0},
+                },
+            },
+        },
     }
     for tdx, testCase := range tests {
         testName := fmt.Sprintf("case: %d", tdx)


### PR DESCRIPTION
This is to add a test for the fluctuation function for entries with only one data point. Given that the delta function experienced a bug with single-data-point sets, I thought it would make sense to check for it in the fluctuation function as well. Fortunately the bug does not exist there so I'm just adding the test by itself. 