### PR TITLE
ENH: Recursive pv names

### DIFF
--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -290,8 +290,8 @@ func IsolateBasicQuery(unparsed string) []string {
     phraseParts := make([][]string, 0, len(multiPhrases))
 
     for idx, _ := range multiPhrases {
-        // Strip parenthesis
-        multiPhrases[idx] = strings.Trim(multiPhrases[idx], "()")
+        // Strip leading and ending parenthesis
+        multiPhrases[idx] = multiPhrases[idx][1:len(multiPhrases[idx])-1]
         // Break parsed phrases on "|"
         phraseParts = append(phraseParts, strings.Split(multiPhrases[idx], "|"))
     }
@@ -309,10 +309,25 @@ func IsolateBasicQuery(unparsed string) []string {
     return result
 }
 
-// func IsolateBasicQueryRecurse( inputData string) []string {
-// 
-// 
-// }
+func SplitLowestLevelOnly(inputData string) []string {
+    output := make([]string,0,5)
+    nestCounter := 0
+    stashInitPos := 0
+    for pos, char := range inputData {
+        switch {
+            case char == '(':
+                nestCounter++
+            case char == ')':
+                nestCounter--
+        }
+        if char == '|' && nestCounter == 0 {
+            output = append(output, inputData[stashInitPos:pos])
+            stashInitPos = pos+1
+        }
+    }
+    output = append(output, inputData[stashInitPos:])
+    return output 
+}
 
 type ParenLoc struct {
     Phrases []string

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -8,7 +8,6 @@ import (
     "strings"
     "strconv"
     "io/ioutil"
-    "regexp"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -281,11 +280,11 @@ func IsolateBasicQuery(unparsed string) []string {
     // This function takes queries in this format and breaks them up into a list of individual PVs
     unparsed_clean := strings.TrimSpace(unparsed)
 
-    multiFinder, _ := regexp.Compile(`\([^)]*?\)`)
+    phrases := LocateOuterParen(unparsed)
     // Identify parenthesis-bound sections
-    multiPhrases := multiFinder.FindAllString(unparsed_clean, -1)
+    multiPhrases := phrases.Phrases
     // Locate parenthesis-bound sections
-    phraseIdxs := multiFinder.FindAllStringIndex(unparsed, -1)
+    phraseIdxs := phrases.Idxs
 
     // A list of all the possible phrases
     phraseParts := make([][]string, 0, len(multiPhrases))

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -310,6 +310,22 @@ func IsolateBasicQuery(unparsed string) []string {
     return result
 }
 
+// func IsolateBasicQueryRecurse( inputData string) []string {
+// 
+// 
+// }
+
+type ParenLoc struct {
+    Phrases []string
+    Idxs [][]int
+}
+
+func LocateOuterParen(inputData string) ParenLoc {
+    var f ParenLoc;
+    f.Phrases = append(f.Phrases, inputData)
+    return f
+}
+
 func PermuteQuery( inputData [][]string) [][]string {
     /*
         Generate all ordered permutations of the input strings to make the following operation occur: 

--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -321,9 +321,27 @@ type ParenLoc struct {
 }
 
 func LocateOuterParen(inputData string) ParenLoc {
-    var f ParenLoc;
-    f.Phrases = append(f.Phrases, inputData)
-    return f
+    var output ParenLoc;
+
+    nestCounter := 0
+    var stashInitPos int
+    for pos, char := range inputData {
+        if char == '(' {
+            if nestCounter == 0 {
+                stashInitPos = pos
+            }
+            nestCounter++
+        }
+        if char == ')' {
+            if nestCounter == 1 {
+                // A completed 1st-level parenthesis set has been completed 
+                output.Phrases = append(output.Phrases, inputData[stashInitPos:pos+1])
+                output.Idxs = append(output.Idxs, []int{stashInitPos, pos+1})
+            }
+            nestCounter--
+        }
+    }
+    return output
 }
 
 func PermuteQuery( inputData [][]string) [][]string {

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -337,6 +337,49 @@ func TestIsolateBasicQuery(t *testing.T) {
     }
 }
 
+func TestSplitLowestLevelOnly(t *testing.T) {
+    var tests = []struct{
+        input string
+        output []string
+    }{
+        {
+            input:   "one (two (three)) (four five) six",
+            output:  []string{"one (two (three)) (four five) six"},
+        },
+        {
+            input:   "one two |three",
+            output:  []string{"one two ", "three"},
+        },
+        {
+            input:   "one two |three | four",
+            output:  []string{"one two ", "three ", " four"},
+        },
+        {
+            input:   "one (two |three) | four",
+            output:  []string{"one (two |three) ", " four"},
+        },
+        // {
+        //     input:   "one (two (three)) (four five) six",
+        //     output:  []string{"one (two (three)) (four five) six"},
+        // },
+    }
+    for idx, testCase := range tests {
+        testName := fmt.Sprintf("%d: %s", idx, testCase.input)
+        t.Run(testName, func(t *testing.T) {
+            result := SplitLowestLevelOnly(testCase.input)
+            if len(result) != len(testCase.output) {
+                t.Fatalf("Lengths differ - Wanted: %v Got: %v", testCase.output, result)
+            }
+            for idx, _ := range(testCase.output) {
+                if testCase.output[idx] != result[idx] {
+                    t.Errorf("got %v, want %v", result, testCase.output)
+                }
+            }
+        })
+    }
+}
+
+
 func TestLocateOuterParen(t *testing.T) {
     var tests = []struct{
         input string

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -317,6 +317,7 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "before:(this|that):is:1", output: []string{"before:this:is:1","before:that:is:1"}},
         {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:this:was:1","before:that:is:1","before:that:was:1"}},
         {inputUnparsed: "()", output: []string{""}},
+        {inputUnparsed: "((this|that):is:1|this:is:2)", output: []string{"this:is:1", "that:is:1", "this:is:2"}},
     }
 
     for idx, testCase := range tests {
@@ -330,6 +331,67 @@ func TestIsolateBasicQuery(t *testing.T) {
             for idx, _ := range(testCase.output) {
                 if testCase.output[idx] != result[idx] {
                     t.Errorf("got %v, want %v", result, testCase.output)
+                }
+            }
+        })
+    }
+}
+
+func TestLocateOuterParen(t *testing.T) {
+    var tests = []struct{
+        input string
+        outputPhrases []string
+        outputIdxs  [][]int
+    }{
+        {
+            input:           "one (two (three)) (four five) six",
+            outputPhrases:  []string{"(two (three))","(four five)"},
+            outputIdxs:     [][]int{{4,17},{18,29}},
+        },
+        {
+            input:           "one (match) (here)",
+            outputPhrases:  []string{"(match)","(here)"},
+            outputIdxs:     [][]int{{4,11},{12,18}},
+        },
+        {
+            input:           "one (match) here",
+            outputPhrases:  []string{"(match)"},
+            outputIdxs:     [][]int{{4,11}},
+        },
+        {
+            input:           "no matches here",
+            outputPhrases:  []string{},
+            outputIdxs:     [][]int{},
+        },
+        // {
+        //     input:           "",  
+        //     outputPhrases:  []string{},
+        //     outputIdxs:     [][]int{},
+        // },
+    }
+    for idx, testCase := range tests {
+        testName := fmt.Sprintf("%d: %s, ", idx, testCase.input)
+        t.Run(testName, func(t *testing.T) {
+            result := LocateOuterParen(testCase.input)
+            // Check Phrases 
+            if len(result.Phrases) != len(testCase.outputPhrases) {
+                t.Fatalf("Lengths differ - Wanted: %v Got: %v", testCase.outputPhrases, result.Phrases)
+            }
+            for idx, _ := range(testCase.outputPhrases) {
+                if testCase.outputPhrases[idx] != result.Phrases[idx] {
+                    t.Errorf("got %v, want %v", result.Phrases, testCase.outputPhrases)
+                }
+            }
+
+            // Check indices
+            if len(result.Idxs) != len(testCase.outputIdxs) {
+                t.Fatalf("Lengths differ - Wanted: %v Got: %v", testCase.outputIdxs, result.Idxs)
+            }
+            for idx, _ := range(testCase.outputPhrases) {
+                for i := 0; i<2; i++ {
+                    if testCase.outputIdxs[idx][i] != result.Idxs[idx][i] {
+                        t.Errorf("got %v, want %v", result.Idxs, testCase.outputIdxs)
+                    }
                 }
             }
         })

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -317,7 +317,7 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "before:(this|that):is:1", output: []string{"before:this:is:1","before:that:is:1"}},
         {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:this:was:1","before:that:is:1","before:that:was:1"}},
         {inputUnparsed: "()", output: []string{""}},
-        {inputUnparsed: "((this|that):is:1|this:is:2)", output: []string{"this:is:1", "that:is:1", "this:is:2"}},
+        {inputUnparsed: "((this|that):is:1|this:is:2)", output: []string{"this:is:2", "this:is:1", "that:is:1"}},
     }
 
     for idx, testCase := range tests {

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -390,7 +390,7 @@ func TestLocateOuterParen(t *testing.T) {
             for idx, _ := range(testCase.outputPhrases) {
                 for i := 0; i<2; i++ {
                     if testCase.outputIdxs[idx][i] != result.Idxs[idx][i] {
-                        t.Errorf("got %v, want %v", result.Idxs, testCase.outputIdxs)
+                        t.Errorf("got %v, want %v", result.Idxs[idx], testCase.outputIdxs[idx])
                     }
                 }
             }

--- a/pkg/archiver-query_test.go
+++ b/pkg/archiver-query_test.go
@@ -318,6 +318,7 @@ func TestIsolateBasicQuery(t *testing.T) {
         {inputUnparsed: "before:(this|that):(is|was):1", output: []string{"before:this:is:1","before:this:was:1","before:that:is:1","before:that:was:1"}},
         {inputUnparsed: "()", output: []string{""}},
         {inputUnparsed: "((this|that):is:1|this:is:2)", output: []string{"this:is:2", "this:is:1", "that:is:1"}},
+        {inputUnparsed: "prefix:((this|that):is:1|this:is:2)", output: []string{"prefix:this:is:2", "prefix:this:is:1", "prefix:that:is:1"}},
     }
 
     for idx, testCase := range tests {


### PR DESCRIPTION
This PR implements @klauer's idea to allow non-regex PV's to handle enclosed parentheses like so:
```
(a(b|c)|d)e
```
Will be expanded to 
```
abe
ace
de
```