### PR TITLE
Backend: Add display name config to dataframe

### DIFF
--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -479,9 +479,9 @@ func FrameBuilder(singleResponse SingleData) *data.Frame {
         )
 
         // add values 
-        frame.Fields = append(frame.Fields,
-            data.NewField(singleResponse.Name, nil, singleResponse.Values),
-        )
+        valueField := data.NewField(singleResponse.Name, nil, singleResponse.Values)
+        valueField.Config = &data.FieldConfig{DisplayName: singleResponse.Name}
+        frame.Fields = append(frame.Fields, valueField)
 
         return frame
 }


### PR DESCRIPTION
Dataframe has FieldConfig that is optional display data for the field (e.g. unit, name over-ride, etc).

Legend name is shown as `"Dataframe name" "Field name"` by #60 PR. This means that the legend name is shown as `"PV name" "PV name"`.

This PR fixes the legend name as just `"PV name"`.