### PR TITLE
BUG: fix initial value of function add button

### DIFF
--- a/src/components/FunctionAdd.tsx
+++ b/src/components/FunctionAdd.tsx
@@ -40,7 +40,7 @@ class FunctionAdd extends React.PureComponent<FunctionAddProps> {
     const categories = getCategories();
     const allFunctions = getAllFunctionNames(categories);
     return (
-      <ButtonCascader options={allFunctions} value={undefined} onChange={this.onChange}>
+      <ButtonCascader options={allFunctions} value={[]} onChange={this.onChange} variant="primary" icon="plus">
         Add
       </ButtonCascader>
     );

--- a/src/components/__snapshots__/FunctionAdd.test.tsx.snap
+++ b/src/components/__snapshots__/FunctionAdd.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Render should render component 1`] = `
 <ButtonCascader
+  icon="plus"
   onChange={[Function]}
   options={
     Array [
@@ -133,6 +134,8 @@ exports[`Render should render component 1`] = `
       },
     ]
   }
+  value={Array []}
+  variant="primary"
 >
   Add
 </ButtonCascader>


### PR DESCRIPTION
This PR fix initial value of function add button. When a cascader button is opened, no function is selected every time.

`plus` icon is also added by this PR.