### PR TITLE
BUG: Fix "json: cannot unmarshal" error (#75)

### DIFF
--- a/pkg/archiver-query.go
+++ b/pkg/archiver-query.go
@@ -43,12 +43,10 @@ type ArchiverQueryModel struct {
 	*/
 
 	// Parameters from DataQuery
-	RefId      string  `json:"refId"`
-	Hide       *bool   `json:"hide"`
-	Key        *string `json:"string"`
-	QueryType  *string `json:"queryType"`
-	DataTopic  *string `json:"dataTopic"`  //??
-	Datasource *string `json:"datasource"` // comes back empty -- investigate further
+	RefId     string  `json:"refId"`
+	Hide      *bool   `json:"hide"`
+	Key       *string `json:"string"`
+	QueryType *string `json:"queryType"`
 }
 
 type FunctionDescriptorQueryModel struct {


### PR DESCRIPTION
Fixes #75

This PR removes unnecessary parameters from QueryModel to fix "json: cannot unmarshal" error.