### PR TITLE
ENH: add array format option function

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -377,9 +377,99 @@ export class DataSource extends DataSourceWithBackend<AAQuery, AADataSourceOptio
   }
 
   parseArrayResponse(targetRes: AADataQueryData, target: TargetQuery) {
+    let fields;
+    if (target.options.arrayFormat == "dt-space") {
+      fields = this.makeDtSpaceArrayFields(targetRes);
+    } else if (target.options.arrayFormat == "index") {
+      fields = this.makeIndexArrayFields(targetRes);
+    } else {
+      fields = this.makeTimeseriesArrayFields(targetRes);
+    }
+
+    if (fields.length == 0) {
+      return new MutableDataFrame();
+    }
+
+    const frame = new MutableDataFrame({
+      refId: target.refId,
+      name: targetRes.meta.name,
+      fields,
+    });
+
+    return frame;
+  }
+
+  makeDtSpaceArrayFields(targetRes: AADataQueryData) {
     // Type check for columnValues
     if (!isNumberArray(targetRes)) {
-      return new MutableDataFrame();
+      return [];
+    }
+
+    const targetData = targetRes.data
+
+    const field_val = _.reduce(
+      targetData,
+      (fields, data, i) => {
+        fields["vals"] = fields["vals"].concat(data.val);
+
+        const len = data.val.length;
+        for (let i = 0; i < len; i++) {
+          const date = data.millis + i;
+          fields["times"].push(date)
+        }
+
+        return fields;
+      },
+      { times: [], vals: [] } as { times: number[]; vals: number[] }
+    );
+
+    const fields = [
+      { name: 'time', type: FieldType.time, values: field_val["times"] },
+      { name: targetRes.meta.name, type: FieldType.number, values: field_val["vals"] }
+    ];
+
+    return fields;
+  }
+
+  makeIndexArrayFields(targetRes: AADataQueryData) {
+    // Type check for columnValues
+    if (!isNumberArray(targetRes)) {
+      return [];
+    }
+
+    const targetData = targetRes.data
+
+    const len = targetData[0].val.length;
+    let numbers = []
+    for (let i = 0; i < len; i++) {
+      numbers.push(i)
+    }
+
+    const fields = [{ name: 'index', type: FieldType.number, values: numbers }];
+
+    _.reduce(
+      targetData,
+      (fields, data, i) => {
+        const date = new Date(data.millis);
+        const val = data.val.length >= len ? data.val.slice(0, len) : data.val;
+        const field = {
+          name: date.toISOString(),
+          type: FieldType.number,
+          values: val,
+        };
+        fields.push(field);
+        return fields;
+      },
+      fields
+    );
+
+    return fields;
+  }
+
+  makeTimeseriesArrayFields(targetRes: AADataQueryData) {
+    // Type check for columnValues
+    if (!isNumberArray(targetRes)) {
+      return [];
     }
 
     const columnValues = _.map(targetRes.data, (datapoint) => datapoint.val);
@@ -403,13 +493,8 @@ export class DataSource extends DataSourceWithBackend<AAQuery, AADataSourceOptio
       fields
     );
 
-    const frame = new MutableDataFrame({
-      refId: target.refId,
-      name: targetRes.meta.name,
-      fields,
-    });
+    return fields;
 
-    return frame;
   }
 
   parseArrayResponseToScalar(
@@ -469,7 +554,7 @@ export class DataSource extends DataSourceWithBackend<AAQuery, AADataSourceOptio
     }
 
     const newDataFrames = _.map(dataFrames, (dataFrame) => {
-      const valfields = _.filter(dataFrame.fields, (field) => field.name !== 'time');
+      const valfields = _.filter(dataFrame.fields, (field) => (field.name !== 'time' && field.name !== 'index'));
 
       const newValfields = _.map(valfields, (valfield) => {
         const displayName = getFieldDisplayName(valfield, dataFrame);

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -680,8 +680,12 @@ export class DataSource extends DataSourceWithBackend<AAQuery, AADataSourceOptio
     }
 
     const from = new Date(String(query.range.from));
-    const to = new Date(String(query.range.to));
-    const rangeMsec = to.getTime() - from.getTime();
+    const to_ = new Date(String(query.range.to));
+    const rangeMsec = to_.getTime() - from.getTime();
+
+    // If "from" == "to" in seconds then "to" should be "to + 1 second"
+    const to = rangeMsec >= 1 ? to_ : new Date(to_.getTime() + 1000);
+
     const maxDataPoints = query.maxDataPoints || 2000;
     const intervalSec = _.floor(rangeMsec / (maxDataPoints * 1000));
 

--- a/src/aafunc.ts
+++ b/src/aafunc.ts
@@ -253,6 +253,13 @@ addFuncDef({
   defaultParams: ['true'],
 });
 
+addFuncDef({
+  name: 'arrayFormat',
+  category: 'Options',
+  params: [{ name: 'format', type: 'string', options: ['timeseries', 'index', 'dt-space'] }],
+  defaultParams: ['timeseries'],
+});
+
 export function getFuncDef(name: string) {
   return funcIndex[name];
 }

--- a/src/components/__snapshots__/FunctionAdd.test.tsx.snap
+++ b/src/components/__snapshots__/FunctionAdd.test.tsx.snap
@@ -128,6 +128,10 @@ exports[`Render should render component 1`] = `
             "label": "disableExtrapol",
             "value": "disableExtrapol",
           },
+          Object {
+            "label": "arrayFormat",
+            "value": "arrayFormat",
+          },
         ],
         "label": "Options",
         "value": "Options",

--- a/src/specs/datasource.test.ts
+++ b/src/specs/datasource.test.ts
@@ -360,6 +360,21 @@ describe('Archiverappliance Datasource', () => {
       expect(targets).toHaveLength(1);
       done();
     });
+
+    it('should return 1 second range when from == to in seconds', (done) => {
+      const options = ({
+        targets: [{ target: 'PV1', refId: 'A' }],
+        range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-01T00:00:00.100Z') },
+        maxDataPoints: 1800,
+      } as unknown) as DataQueryRequest<AAQuery>;
+
+      const targets = ds.buildQueryParameters(options);
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0].from.getTime()).toBe(new Date('2010-01-01T00:00:00.000Z').getTime());
+      expect(targets[0].to.getTime()).toBe(new Date('2010-01-01T00:00:01.000Z').getTime());
+      done();
+    });
   });
 
   describe('Query tests', () => {

--- a/src/specs/datasource.test.ts
+++ b/src/specs/datasource.test.ts
@@ -524,6 +524,196 @@ describe('Archiverappliance Datasource', () => {
       });
     });
 
+    it('should return dt-space array data when waveform is true and arrayFormat is dt-space', (done) => {
+      datasourceRequestMock.mockImplementation((request) =>
+        Promise.resolve({
+          data: [
+            {
+              meta: { name: 'header:PV1', PREC: '0', waveform: true },
+              data: [
+                { millis: 1262304000000, val: [1, 2, 3] },
+                { millis: 1262304001000, val: [4, 5, 6] },
+                { millis: 1262304002000, val: [7, 8, 9, 10] },
+              ],
+            },
+          ],
+        })
+      );
+
+      const query = ({
+        targets: [
+          {
+            target: 'header:PV1',
+            refId: 'A',
+            functions: [{ params: ["dt-space"], def: { category: "Options", name: "arrayFormat", params: [{ name: 'format', type: 'string', options: ['timeseries', 'index', 'dt-space'] }] } }],
+          },
+        ],
+        range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-01T00:00:30.000Z') },
+        maxDataPoints: 1000,
+      } as unknown) as DataQueryRequest<AAQuery>;
+
+      ds.query(query).subscribe((result: any) => {
+        expect(result.data).toHaveLength(1);
+        const dataFrame: MutableDataFrame = result.data[0];
+        expect(dataFrame.fields).toHaveLength(2);
+
+        const seriesName = dataFrame.name;
+        expect(seriesName).toBe('header:PV1');
+
+        const timesArray = dataFrame.fields[0].values.toArray();
+        expect(timesArray).toHaveLength(11);
+        expect(timesArray[0]).toBe(1262304000000);
+        expect(timesArray[1]).toBe(1262304000001);
+        expect(timesArray[2]).toBe(1262304000002);
+        expect(timesArray[9]).toBe(1262304002003);
+
+        const name1 = getFieldDisplayName(dataFrame.fields[1], dataFrame);
+        expect(name1).toBe('header:PV1');
+
+        const valArray = dataFrame.fields[1].values.toArray();
+        expect(valArray).toHaveLength(11);
+
+        expect(valArray[0]).toBe(1);
+        expect(valArray[1]).toBe(2);
+        expect(valArray[2]).toBe(3);
+        expect(valArray[9]).toBe(10);
+        expect(valArray[10]).toBe(10);
+
+        done();
+      });
+    });
+
+    it('should return index array data when waveform is true and arrayFormat is index', (done) => {
+      datasourceRequestMock.mockImplementation((request) =>
+        Promise.resolve({
+          data: [
+            {
+              meta: { name: 'header:PV1', PREC: '0', waveform: true },
+              data: [
+                { millis: 1262304000123, val: [1, 2, 3] },
+                { millis: 1262304001456, val: [4, 5, 6] },
+                { millis: 1262304002789, val: [7, 8, 9, 10] },
+              ],
+            },
+          ],
+        })
+      );
+
+      const query = ({
+        targets: [
+          {
+            target: 'header:PV1',
+            refId: 'A',
+            functions: [{ params: ["index"], def: { category: "Options", name: "arrayFormat", params: [{ name: 'format', type: 'string', options: ['timeseries', 'index', 'dt-space'] }] } }],
+          },
+        ],
+        range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-01T00:00:30.000Z') },
+        maxDataPoints: 1000,
+      } as unknown) as DataQueryRequest<AAQuery>;
+
+      ds.query(query).subscribe((result: any) => {
+        expect(result.data).toHaveLength(1);
+        const dataFrame: MutableDataFrame = result.data[0];
+        expect(dataFrame.fields).toHaveLength(4);
+
+        const seriesName = dataFrame.name;
+        expect(seriesName).toBe('header:PV1');
+
+        const indexArray = dataFrame.fields[0].values.toArray();
+        expect(indexArray[0]).toBe(0);
+        expect(indexArray[1]).toBe(1);
+        expect(indexArray[2]).toBe(2);
+
+        const name0 = getFieldDisplayName(dataFrame.fields[0], dataFrame);
+        const name1 = getFieldDisplayName(dataFrame.fields[1], dataFrame);
+        const name2 = getFieldDisplayName(dataFrame.fields[2], dataFrame);
+        const name3 = getFieldDisplayName(dataFrame.fields[3], dataFrame);
+        expect(name0).toBe("index");
+        expect(name1).toBe(new Date(1262304000123).toISOString());
+        expect(name2).toBe(new Date(1262304001456).toISOString());
+        expect(name3).toBe(new Date(1262304002789).toISOString());
+
+        const valArray1 = dataFrame.fields[1].values.toArray();
+        const valArray2 = dataFrame.fields[2].values.toArray();
+        const valArray3 = dataFrame.fields[3].values.toArray();
+
+        expect(valArray1).toHaveLength(4);
+        expect(valArray2).toHaveLength(4);
+        expect(valArray3).toHaveLength(4);
+
+        expect(valArray1[0]).toBe(1);
+        expect(valArray1[1]).toBe(2);
+        expect(valArray1[2]).toBe(3);
+        expect(valArray1[3]).toBe(3);
+
+        done();
+      });
+    });
+
+    it('should return timeseries array data when waveform is true and arrayFormat is timeseries', (done) => {
+      datasourceRequestMock.mockImplementation((request) =>
+        Promise.resolve({
+          data: [
+            {
+              meta: { name: 'header:PV1', PREC: '0', waveform: true },
+              data: [
+                { millis: 1262304000123, val: [1, 2, 3] },
+                { millis: 1262304001456, val: [4, 5, 6] },
+                { millis: 1262304002789, val: [7, 8, 9, 10] },
+              ],
+            },
+          ],
+        })
+      );
+
+      const query = ({
+        targets: [
+          {
+            target: 'header:PV1',
+            refId: 'A',
+            options: { arrayFormat: "timeseries" },
+          },
+        ],
+        range: { from: new Date('2010-01-01T00:00:00.000Z'), to: new Date('2010-01-01T00:00:30.000Z') },
+        maxDataPoints: 1000,
+      } as unknown) as DataQueryRequest<AAQuery>;
+
+      ds.query(query).subscribe((result: any) => {
+        expect(result.data).toHaveLength(1);
+        const dataFrame: MutableDataFrame = result.data[0];
+        expect(dataFrame.fields).toHaveLength(5);
+
+        const seriesName = dataFrame.name;
+        expect(seriesName).toBe('header:PV1');
+
+        const timesArray = dataFrame.fields[0].values.toArray();
+        expect(timesArray[0]).toBe(1262304000123);
+
+        const name1 = getFieldDisplayName(dataFrame.fields[1], dataFrame);
+        const name2 = getFieldDisplayName(dataFrame.fields[2], dataFrame);
+        const name3 = getFieldDisplayName(dataFrame.fields[3], dataFrame);
+        expect(name1).toBe('header:PV1[0]');
+        expect(name2).toBe('header:PV1[1]');
+        expect(name3).toBe('header:PV1[2]');
+
+        const valArray1 = dataFrame.fields[1].values.toArray();
+        const valArray2 = dataFrame.fields[2].values.toArray();
+        const valArray3 = dataFrame.fields[3].values.toArray();
+        const valArray4 = dataFrame.fields[4].values.toArray();
+        expect(valArray1).toHaveLength(4);
+        expect(valArray2).toHaveLength(4);
+        expect(valArray3).toHaveLength(4);
+        expect(valArray4).toHaveLength(4);
+
+        expect(valArray1[0]).toBe(1);
+        expect(valArray1[1]).toBe(4);
+        expect(valArray1[2]).toBe(7);
+        expect(valArray1[3]).toBe(7);
+
+        done();
+      });
+    });
+
     it('should return the server results with alias', (done) => {
       datasourceRequestMock.mockImplementation((request) => {
         const pv = request.url.slice(31, 34);


### PR DESCRIPTION
This PR fixes #83.

`arrayFormat` function provides 3 types of array format: `timeseries`, `index`, and `dt-space`.

Assume that we have following array data:

```
[
    {
        "meta": {
            "name": "PV:NAME",
            "waveform": true,
            "PREC": "0"
        },
        "data": [
            {
                "millis": 1577804410000,
                "val": [
                    val1_1, val1_2, val1_3, val1_4, ..., val1_361
                ]
            },
            {
                "millis": 1577804510000,
                "val": [
                    val2_1, val2_2, val2_3, val2_4, ..., val2_361
                ]
            }
        ]
    }
]
```

Each format should return as following:

**timeseries**

| time          | PV:NAME[0] | PV:NAME[1] | ... | PV:NAME[360] |
| ------------- | -------- | -------- | -------- | -------- |
| 1577804410000 | val1_1 | val1_2 | ... | val1_361 |
| 1577804510000 | val2_1 | val2_2 | ... | val2_361 |

**index**

| index         | 2020-01-01T00:00:10.000Z   |2020-01-01T00:01:50.000Z   |
| ------------- | -------- | -------- |
| 0 | val1_1   | val2_1 |
| 1 | val1_2   | val2_2 |
| ...           | ...      | ... |
| 360 | val1_361 | val2_361 |

**dt-space**

| time          | PV:NAME   |
| ------------- | -------- |
| 1577804410000 | val1_1   |
| 1577804410001 | val1_2   |
| ...           | ...      |
| 1577804410360 | val1_361 |
| 1577804510000 | val2_1   |
| 1577804510001 | val2_2   |
| ...           | ...      |
| 1577804510360 | val2_361 |