### PR TITLE
BUG: enable extrapolation even if operator is not raw

### DIFF
--- a/pkg/aaclient_test.go
+++ b/pkg/aaclient_test.go
@@ -45,6 +45,7 @@ func TestBuildQueryUrl(t *testing.T) {
 					From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")),
 					To:   MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:30:41.678-08:00")),
 				},
+				Interval: 0,
 			},
 			output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=MR1K1%3ABEND%3APIP%3A1%3APMON&to=2021-01-27T14%3A30%3A41.678-08%3A00",
 		},
@@ -65,6 +66,7 @@ func TestBuildQueryUrl(t *testing.T) {
 					From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")),
 					To:   MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T16:25:41.678-08:00")),
 				},
+				Interval: 7,
 			},
 			output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=mean_7%28MR1K1%3ABEND%3APIP%3A1%3APMON%29&to=2021-01-27T16%3A25%3A41.678-08%3A00",
 		},
@@ -85,6 +87,7 @@ func TestBuildQueryUrl(t *testing.T) {
 					From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")),
 					To:   MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:30:41.678-08:00")),
 				},
+				Interval: 0,
 			},
 			output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=MR1K1%3ABEND%3APIP%3A1%3APMON&to=2021-01-27T14%3A30%3A41.678-08%3A00",
 		},
@@ -105,59 +108,9 @@ func TestBuildQueryUrl(t *testing.T) {
 					From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")),
 					To:   MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T16:25:41.678-08:00")),
 				},
+				Interval: 7,
 			},
 			output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=max_7%28MR1K1%3ABEND%3APIP%3A1%3APMON%29&to=2021-01-27T16%3A25%3A41.678-08%3A00",
-		},
-		{
-			name:   "URL for median operator and fixed interval",
-			target: "MR1K1:BEND:PIP:1:PMON",
-			url:    "http://localhost:3396/retrieval",
-			qm: ArchiverQueryModel{
-				IntervalMs: InitIntPointer(300),
-				// alias: ,
-				// aliasPattern: ,
-				// constant: 6.5,
-				// dataTopic: nil,
-				// datasource: nil,
-				// format: ,
-				Functions: []FunctionDescriptorQueryModel{
-					{
-						Def: FuncDefQueryModel{
-							// Fake:<nil>
-							Category:      "Options",
-							DefaultParams: InitRawMsg(`[900]`),
-							Name:          "binInterval",
-							Params: []FuncDefParamQueryModel{
-								{Name: "interval", Type: "int"},
-							},
-						},
-						Params: []string{"900"},
-					},
-					{
-						Def: FuncDefQueryModel{
-							// Fake:<nil>
-							Category:      "Transform",
-							DefaultParams: InitRawMsg(`[]`),
-							Name:          "delta",
-							Params:        []FuncDefParamQueryModel{},
-						},
-						Params: []string{},
-					},
-				},
-				// Hide: false,
-				Operator:  "median",
-				QueryText: "",
-				QueryType: nil,
-				RefId:     "A",
-				Regex:     true,
-				// String: nil,
-				Target: "MR1K1:BEND:PIP:1:PMON",
-				TimeRange: backend.TimeRange{
-					From: MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:25:41.678-08:00")),
-					To:   MultiReturnHelperParse(time.Parse(TIME_FORMAT, "2021-01-27T14:30:41.678-08:00")),
-				},
-			},
-			output: "http://localhost:3396/retrieval/data/getData.qw?donotchunk=&from=2021-01-27T14%3A25%3A41.678-08%3A00&pv=median_900%28MR1K1%3ABEND%3APIP%3A1%3APMON%29&to=2021-01-27T14%3A30%3A41.678-08%3A00",
 		},
 	}
 	// fmt.Println(tests)

--- a/pkg/models.go
+++ b/pkg/models.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -40,6 +42,7 @@ type ArchiverQueryModel struct {
 
 	// Not from JSON
 	TimeRange backend.TimeRange `json:"-"`
+	Interval  int               `json:"-"`
 }
 
 type FunctionDescriptorQueryModel struct {
@@ -162,8 +165,12 @@ func ReadQueryModel(query backend.DataQuery) (ArchiverQueryModel, error) {
 		return model, fmt.Errorf("error reading query: %s", err.Error())
 	}
 
-	// Copy directly from the well typed query
+	// Parameters Not from JSON
 	model.TimeRange = query.TimeRange
+	model.Interval, err = loadInterval(model)
+	if err != nil {
+		model.Interval = 0
+	}
 	return model, nil
 }
 
@@ -173,4 +180,40 @@ func LoadSettings(ctx backend.PluginContext) (DatasourceSettings, error) {
 	model.URL = ctx.DataSourceInstanceSettings.URL
 
 	return model, nil
+}
+
+func loadInterval(qm ArchiverQueryModel) (int, error) {
+	// No operators are necessary in this case
+	if qm.Operator == "raw" || qm.Operator == "last" {
+		return 0, nil
+	}
+
+	var interval int
+	intervals := qm.IdentifyFunctionsByName("binInterval")
+
+	// Determine the bin interval size given by the user and detect issues
+	if len(intervals) >= 1 {
+		if len(intervals) > 1 {
+			log.DefaultLogger.Warn(fmt.Sprintf("more than one binInterval has been provided: %v", intervals))
+		}
+
+		val, paramErr := intervals[0].GetParametersByName("interval")
+		if paramErr != nil {
+			log.DefaultLogger.Warn("Conversion of binInterval argument has failed", "Error", paramErr)
+			return 0, paramErr
+		}
+
+		var atoiErr error
+		interval, atoiErr = strconv.Atoi(val)
+		if atoiErr != nil {
+			log.DefaultLogger.Warn("Failed to convert parameter string to integer", "Error", atoiErr)
+			return 0, atoiErr
+		}
+	} else if len(intervals) == 0 && qm.IntervalMs != nil {
+		// interval is not given by user, so interval is determined by IntervalMs
+		intervalMs := float64(*qm.IntervalMs)
+		interval = int(math.Floor(intervalMs / 1000)) // convert to seconds
+	}
+
+	return interval, nil
 }

--- a/pkg/models.go
+++ b/pkg/models.go
@@ -41,8 +41,9 @@ type ArchiverQueryModel struct {
 	QueryType *string `json:"queryType"`
 
 	// Not from JSON
-	TimeRange backend.TimeRange `json:"-"`
-	Interval  int               `json:"-"`
+	TimeRange    backend.TimeRange `json:"-"`
+	Interval     int               `json:"-"`
+	BackendQuery bool              `json:"-"`
 }
 
 type FunctionDescriptorQueryModel struct {
@@ -170,6 +171,9 @@ func ReadQueryModel(query backend.DataQuery) (ArchiverQueryModel, error) {
 	model.Interval, err = loadInterval(model)
 	if err != nil {
 		model.Interval = 0
+	}
+	if model.IntervalMs == nil {
+		model.BackendQuery = true
 	}
 	return model, nil
 }

--- a/pkg/operators.go
+++ b/pkg/operators.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -58,15 +57,11 @@ func CreateOperatorQuery(qm ArchiverQueryModel) (string, error) {
 	}
 
 	// No operators are necessary in this case
-	if (qm.Operator == "" && qm.IntervalMs == nil) || qm.Operator == "raw" || qm.Operator == "last" {
+	if qm.Operator == "raw" || qm.Operator == "last" {
 		return "", nil
 	}
 
-	// Load interval from query model
-	binInterval, err := loadInterval(qm)
-	if err != nil {
-		return "", err
-	}
+	binInterval := qm.Interval
 
 	// interval is less than 1 second or interval is not updated from "zero value"
 	if binInterval < 1 {
@@ -84,35 +79,4 @@ func CreateOperatorQuery(qm ArchiverQueryModel) (string, error) {
 	opBuilder.WriteString(strconv.Itoa(binInterval))
 
 	return opBuilder.String(), nil
-}
-
-func loadInterval(qm ArchiverQueryModel) (int, error) {
-	var interval int
-	intervals := qm.IdentifyFunctionsByName("binInterval")
-
-	// Determine the bin interval size given by the user and detect issues
-	if len(intervals) >= 1 {
-		if len(intervals) > 1 {
-			log.DefaultLogger.Warn(fmt.Sprintf("more than one binInterval has been provided: %v", intervals))
-		}
-
-		val, paramErr := intervals[0].GetParametersByName("interval")
-		if paramErr != nil {
-			log.DefaultLogger.Warn("Conversion of binInterval argument has failed", "Error", paramErr)
-			return 0, paramErr
-		}
-
-		var atoiErr error
-		interval, atoiErr = strconv.Atoi(val)
-		if atoiErr != nil {
-			log.DefaultLogger.Warn("Failed to convert parameter string to integer", "Error", atoiErr)
-			return 0, atoiErr
-		}
-	} else if len(intervals) == 0 && qm.IntervalMs != nil {
-		// interval is not given by user, so interval is determined by IntervalMs
-		intervalMs := float64(*qm.IntervalMs)
-		interval = int(math.Floor(intervalMs / 1000)) // convert to seconds
-	}
-
-	return interval, nil
 }

--- a/pkg/operators_test.go
+++ b/pkg/operators_test.go
@@ -33,6 +33,87 @@ func TestCreateOperatorQuery(t *testing.T) {
 		output string
 	}{
 		{
+			name: "mean with 10 second Interval",
+			input: ArchiverQueryModel{
+				Operator: "mean",
+				Interval: 10,
+			},
+			output: "mean_10",
+		},
+		{
+			name: "raw with binInterval function",
+			input: ArchiverQueryModel{
+				Operator: "raw",
+				Interval: 16,
+			},
+			output: "",
+		},
+		{
+			name: "empty operator with 0 second interval",
+			input: ArchiverQueryModel{
+				IntervalMs: InitIntPointer(100),
+				Operator:   "",
+				Interval:   0,
+			},
+			output: "",
+		},
+		{
+			name: "max operator with 10 second interval",
+			input: ArchiverQueryModel{
+				Operator: "max",
+				Interval: 10,
+			},
+			output: "max_10",
+		},
+		{
+			name: "max operator with 0.1 second interval",
+			input: ArchiverQueryModel{
+				Operator: "max",
+				Interval: 0,
+			},
+			output: "",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := CreateOperatorQuery(testCase.input)
+			if err != nil {
+				t.Errorf("Error received %v", err)
+			}
+			if testCase.output != result {
+				t.Errorf("got %v, want %v", result, testCase.output)
+			}
+		})
+	}
+}
+
+func TestLoadInterval(t *testing.T) {
+	var tests = []struct {
+		name   string
+		input  ArchiverQueryModel
+		output int
+	}{
+		{
+			name: "Empty Operator with binInterval function",
+			input: ArchiverQueryModel{
+				Functions: []FunctionDescriptorQueryModel{
+					{
+						Def: FuncDefQueryModel{
+							Category:      "Options",
+							DefaultParams: InitRawMsg(`[16]`),
+							Name:          "binInterval",
+							Params: []FuncDefParamQueryModel{
+								{Name: "interval", Type: "int"},
+							},
+						},
+						Params: []string{"16"},
+					},
+				},
+				Operator: "",
+			},
+			output: 16,
+		},
+		{
 			name: "mean with binInterval function",
 			input: ArchiverQueryModel{
 				Functions: []FunctionDescriptorQueryModel{
@@ -50,7 +131,7 @@ func TestCreateOperatorQuery(t *testing.T) {
 				},
 				Operator: "mean",
 			},
-			output: "mean_16",
+			output: 16,
 		},
 		{
 			name: "raw with binInterval function",
@@ -70,7 +151,27 @@ func TestCreateOperatorQuery(t *testing.T) {
 				},
 				Operator: "raw",
 			},
-			output: "",
+			output: 0,
+		},
+		{
+			name: "last with binInterval function",
+			input: ArchiverQueryModel{
+				Functions: []FunctionDescriptorQueryModel{
+					{
+						Def: FuncDefQueryModel{
+							Category:      "Options",
+							DefaultParams: InitRawMsg(`[16]`),
+							Name:          "binInterval",
+							Params: []FuncDefParamQueryModel{
+								{Name: "interval", Type: "int"},
+							},
+						},
+						Params: []string{"16"},
+					},
+				},
+				Operator: "last",
+			},
+			output: 0,
 		},
 		{
 			name: "empty operator with 10.1 second interval",
@@ -78,7 +179,7 @@ func TestCreateOperatorQuery(t *testing.T) {
 				IntervalMs: InitIntPointer(10100),
 				Operator:   "",
 			},
-			output: "mean_10",
+			output: 10,
 		},
 		{
 			name: "empty operator with 0.1 second interval",
@@ -86,7 +187,7 @@ func TestCreateOperatorQuery(t *testing.T) {
 				IntervalMs: InitIntPointer(100),
 				Operator:   "",
 			},
-			output: "",
+			output: 0,
 		},
 		{
 			name: "max operator with 10 second interval",
@@ -94,35 +195,35 @@ func TestCreateOperatorQuery(t *testing.T) {
 				IntervalMs: InitIntPointer(10100),
 				Operator:   "max",
 			},
-			output: "max_10",
+			output: 10,
 		},
 		{
-			name: "max operator with 0.1 second interval",
+			name: "raw operator with 10 second interval",
 			input: ArchiverQueryModel{
-				IntervalMs: InitIntPointer(100),
-				Operator:   "max",
+				IntervalMs: InitIntPointer(10100),
+				Operator:   "raw",
 			},
-			output: "",
+			output: 0,
 		},
 		{
-			name: "max operator with 1 second interval",
+			name: "last operator with 10 second interval",
 			input: ArchiverQueryModel{
-				IntervalMs: InitIntPointer(1000),
-				Operator:   "max",
+				IntervalMs: InitIntPointer(10100),
+				Operator:   "raw",
 			},
-			output: "max_1",
+			output: 0,
 		},
 		{
 			name: "max operator without IntervalMs",
 			input: ArchiverQueryModel{
 				Operator: "max",
 			},
-			output: "",
+			output: 0,
 		},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			result, err := CreateOperatorQuery(testCase.input)
+			result, err := loadInterval(testCase.input)
 			if err != nil {
 				t.Errorf("Error received %v", err)
 			}

--- a/pkg/query.go
+++ b/pkg/query.go
@@ -169,7 +169,7 @@ func dataExtrapol(singleResponse *SingleData, qm ArchiverQueryModel) *SingleData
 		disableExtrapol = false
 	}
 
-	if (qm.Operator != "raw") || disableExtrapol {
+	if qm.Interval >= 1 || qm.Operator == "last" || disableExtrapol || qm.BackendQuery {
 		return singleResponse
 	}
 

--- a/pkg/query_test.go
+++ b/pkg/query_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -276,11 +275,13 @@ func TestApplyAlias(t *testing.T) {
 
 func TestDataExtrapol(t *testing.T) {
 	var tests = []struct {
+		name  string
 		sDIn  SingleData
 		qm    ArchiverQueryModel
 		sDOut SingleData
 	}{
 		{
+			name: "Interval is 0: raw mode",
 			sDIn: SingleData{
 				Values: &Scalars{
 					Times:  []time.Time{TimeHelper(0)},
@@ -288,11 +289,11 @@ func TestDataExtrapol(t *testing.T) {
 				},
 			},
 			qm: ArchiverQueryModel{
-				Operator: "raw",
 				TimeRange: backend.TimeRange{
 					From: TimeHelper(1),
 					To:   TimeHelper(5),
 				},
+				Interval: 0,
 			},
 			sDOut: SingleData{
 				Values: &Scalars{
@@ -302,6 +303,7 @@ func TestDataExtrapol(t *testing.T) {
 			},
 		},
 		{
+			name: "Interval is 1: normal mode",
 			sDIn: SingleData{
 				Values: &Scalars{
 					Times:  []time.Time{TimeHelper(0)},
@@ -313,6 +315,7 @@ func TestDataExtrapol(t *testing.T) {
 					From: TimeHelper(1),
 					To:   TimeHelper(5),
 				},
+				Interval: 1,
 			},
 			sDOut: SingleData{
 				Values: &Scalars{
@@ -322,6 +325,7 @@ func TestDataExtrapol(t *testing.T) {
 			},
 		},
 		{
+			name: "Disable Extrapolation flag is false",
 			sDIn: SingleData{
 				Values: &Scalars{
 					Times:  []time.Time{TimeHelper(0)},
@@ -342,11 +346,11 @@ func TestDataExtrapol(t *testing.T) {
 						Params: []string{"false"},
 					},
 				},
-				Operator: "raw",
 				TimeRange: backend.TimeRange{
 					From: TimeHelper(1),
 					To:   TimeHelper(5),
 				},
+				Interval: 0,
 			},
 			sDOut: SingleData{
 				Values: &Scalars{
@@ -356,6 +360,7 @@ func TestDataExtrapol(t *testing.T) {
 			},
 		},
 		{
+			name: "Disable Extrapolation flag is true",
 			sDIn: SingleData{
 				Values: &Scalars{
 					Times:  []time.Time{TimeHelper(0)},
@@ -381,6 +386,7 @@ func TestDataExtrapol(t *testing.T) {
 					From: TimeHelper(1),
 					To:   TimeHelper(5),
 				},
+				Interval: 0,
 			},
 			sDOut: SingleData{
 				Values: &Scalars{
@@ -390,6 +396,7 @@ func TestDataExtrapol(t *testing.T) {
 			},
 		},
 		{
+			name: "last operator",
 			sDIn: SingleData{
 				Values: &Scalars{
 					Times:  []time.Time{TimeHelper(0), TimeHelper(3)},
@@ -401,6 +408,8 @@ func TestDataExtrapol(t *testing.T) {
 					From: TimeHelper(1),
 					To:   TimeHelper(5),
 				},
+				Operator: "last",
+				Interval: 0,
 			},
 			sDOut: SingleData{
 				Values: &Scalars{
@@ -410,9 +419,8 @@ func TestDataExtrapol(t *testing.T) {
 			},
 		},
 	}
-	for idx, testCase := range tests {
-		testName := fmt.Sprintf("%d:", idx)
-		t.Run(testName, func(t *testing.T) {
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
 			result := dataExtrapol(&testCase.sDIn, testCase.qm)
 			SingleDataCompareHelper(
 				[]*SingleData{result},


### PR DESCRIPTION
Data extrapolation should be enabled even if operator is not raw.
This PR fixes this.