### PR TITLE
BUG: alternative pattern doesn't work correctly

### DIFF
--- a/pkg/archiverappliance/pvparser.go
+++ b/pkg/archiverappliance/pvparser.go
@@ -1,6 +1,8 @@
 package archiverappliance
 
-import "strings"
+import (
+	"strings"
+)
 
 func isolateBasicQuery(unparsed string) []string {
 	// Non-regex queries can request multiple PVs using this syntax: (PV:NAME:1|PV:NAME:2|...)
@@ -132,8 +134,10 @@ func permuteQueryRecurse(inputData [][]string, trace []string) [][]string {
 
 	// If you've assigned a value for each phrase, just return the full sequence of phrases
 	if len(trace) == len(inputData) {
+		c := make([]string, len(trace))
+		copy(c, trace)
 		output := make([][]string, 0, 1)
-		output = append(output, trace)
+		output = append(output, c)
 		return output
 	}
 
@@ -145,6 +149,7 @@ func permuteQueryRecurse(inputData [][]string, trace []string) [][]string {
 	output := make([][]string, 0, len(inputData[targetIdx]))
 	for _, value := range inputData[targetIdx] {
 		response := permuteQueryRecurse(inputData, append(trace, value))
+
 		output = append(output, response...)
 	}
 	return output

--- a/pkg/archiverappliance/pvparser_test.go
+++ b/pkg/archiverappliance/pvparser_test.go
@@ -20,6 +20,7 @@ func TestIsolateBasicQuery(t *testing.T) {
 		{inputUnparsed: "()", output: []string{""}},
 		{inputUnparsed: "((this|that):is:1|this:is:2)", output: []string{"this:is:2", "this:is:1", "that:is:1"}},
 		{inputUnparsed: "prefix:((this|that):is:1|this:is:2)", output: []string{"prefix:this:is:2", "prefix:this:is:1", "prefix:that:is:1"}},
+		{inputUnparsed: "(prefix):(this):(is):(1|2)", output: []string{"prefix:this:is:1", "prefix:this:is:2"}},
 	}
 
 	for idx, testCase := range tests {
@@ -152,6 +153,8 @@ func TestPermuteQuery(t *testing.T) {
 		{input: [][]string{{"a"}, {"b"}}, output: [][]string{{"a", "b"}}},
 		{input: [][]string{{"a"}}, output: [][]string{{"a"}}},
 		{input: [][]string{{"a", "b"}}, output: [][]string{{"a"}, {"b"}}},
+		{input: [][]string{{"a"}, {"b"}, {"c", "d"}}, output: [][]string{{"a", "b", "c"}, {"a", "b", "d"}}},
+		{input: [][]string{{"a"}, {"b"}, {"c"}, {"d", "e"}}, output: [][]string{{"a", "b", "c", "d"}, {"a", "b", "c", "e"}}},
 		{input: [][]string{{}}, output: [][]string{}},
 		{input: [][]string{}, output: [][]string{{}}},
 	}


### PR DESCRIPTION
Query for `(a):(b):(c):(d|e)` should return `abcd` and `abce` PVs. However the backend returned `abce` and `abce`.

This PR fixes this problem.