### PR TITLE
BUG: fix invalid response handling

### DIFF
--- a/pkg/archiverappliance/aaclient.go
+++ b/pkg/archiverappliance/aaclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -42,8 +43,8 @@ func (client AAclient) ExecuteSingleQuery(target string, qm models.ArchiverQuery
 	// target: This is the PV to be queried for. As the "query" argument may be a regular expression, the specific PV desired must be specified
 	queryUrl := buildQueryUrl(target, client.baseURL, qm)
 	queryResponse, _ := archiverSingleQuery(queryUrl)
-	parsedResponse, _ := archiverSingleQueryParser(queryResponse)
-	return parsedResponse, nil
+	parsedResponse, err := archiverSingleQueryParser(queryResponse)
+	return parsedResponse, err
 }
 
 func buildQueryUrl(target string, baseURL string, qm models.ArchiverQueryModel) string {
@@ -138,7 +139,8 @@ func archiverSingleQueryParser(jsonAsBytes []byte) (models.SingleData, error) {
 	jsonErr := json.Unmarshal(jsonAsBytes, &response)
 	if jsonErr != nil {
 		log.DefaultLogger.Warn("Conversion of incoming data to JSON has failed", "Error", jsonErr)
-		return sD, jsonErr
+		err := fmt.Errorf("response parse error. the response might have invalid data, e.g. infinity or null: %w", jsonErr)
+		return sD, err
 	}
 
 	if len(response) < 1 {

--- a/pkg/archiverappliance/aaclient_test.go
+++ b/pkg/archiverappliance/aaclient_test.go
@@ -286,6 +286,41 @@ func TestArchiverSingleQueryParserEmpty(t *testing.T) {
 	}
 }
 
+func TestArchiverSingleQueryParserInvalidData(t *testing.T) {
+	var dataNames = []struct {
+		name     string
+		fileName string
+	}{
+		{
+			name:     "infinity data",
+			fileName: "../test_data/invalid_value_response.JSON",
+		},
+	}
+
+	type testData struct {
+		input []byte
+		name  string
+	}
+
+	var tests []testData
+	for _, entry := range dataNames {
+		fileData, err := ioutil.ReadFile(entry.fileName)
+		if err != nil {
+			t.Fatalf("Failed to load test data: %v", err)
+		}
+		tests = append(tests, testData{input: fileData, name: entry.name})
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := archiverSingleQueryParser(testCase.input)
+			if err == nil {
+				t.Fatalf("An unexpected error has occurred")
+			}
+		})
+	}
+}
+
 func TestArchiverRegexQueryParser(t *testing.T) {
 	var tests = []struct {
 		input  []byte

--- a/pkg/test_data/invalid_value_response.JSON
+++ b/pkg/test_data/invalid_value_response.JSON
@@ -1,0 +1,28 @@
+[
+    {
+        "meta": {
+            "name": "PFRVA:NEG:2NDSYS:PLASM:RESIS",
+            "waveform": false,
+            "EGU": "ohm",
+            "PREC": "0"
+        },
+        "data": [
+            {
+                "millis": 1667786399401,
+                "val": -Infinity
+            },
+            {
+                "millis": 1667786401400,
+                "val": null
+            },
+            {
+                "millis": 1667786408400,
+                "val": -Infinity
+            },
+            {
+                "millis": 1667786409400,
+                "val": null
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Archiver Appliance may return a response that contains `null` or `Infinity` values as follows.

```json
[ 
{ "meta": { "name": "PFRVA:NEG:2NDSYS:PLASM:RESIS" , "waveform": false , "EGU": "ohm" , "PREC": "0" },
"data": [ 
{ "millis": 1667786399401, "val": -Infinity },
{ "millis": 1667786401400, "val": null },
{ "millis": 1667786408400, "val": -Infinity },
{ "millis": 1667786409400, "val": null }] }
 ]
```

This PR fixes the plugin to return an error response in this case.