### PR TITLE
ENH: return frames even if a response error occurs

### DIFF
--- a/pkg/archiverappliance/aaclient.go
+++ b/pkg/archiverappliance/aaclient.go
@@ -44,6 +44,9 @@ func (client AAclient) ExecuteSingleQuery(target string, qm models.ArchiverQuery
 	queryUrl := buildQueryUrl(target, client.baseURL, qm)
 	queryResponse, _ := archiverSingleQuery(queryUrl)
 	parsedResponse, err := archiverSingleQueryParser(queryResponse)
+	if err != nil {
+		err = fmt.Errorf("target = %q: %w", target, err)
+	}
 	return parsedResponse, err
 }
 

--- a/pkg/archiverappliance/query_test.go
+++ b/pkg/archiverappliance/query_test.go
@@ -28,7 +28,7 @@ func (f fakeClient) FetchRegexTargetPVs(regex string, limit int) ([]string, erro
 }
 
 func (f fakeClient) ExecuteSingleQuery(target string, qm models.ArchiverQueryModel) (models.SingleData, error) {
-	if target == "invalid" {
+	if target == "invalid" || target == "invalid2" {
 		return models.SingleData{}, errors.New("test error")
 	}
 
@@ -352,7 +352,7 @@ func TestQueryWithInvalidResponse(t *testing.T) {
                     		"operator": "",
                     		"refId":"A" ,
                     		"regex":false ,
-                    		"target":"invalid" ,
+                    		"target":"(invalid|invalid2|PV:NAME1)" ,
 							"functions":[
 							]
 						}`),
@@ -372,8 +372,15 @@ func TestQueryWithInvalidResponse(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			result := Query(testCase.ctx, f, testCase.req)
-			if result.Responses["A"].Error == nil {
+			res := result.Responses["A"]
+			if res.Error == nil {
 				t.Errorf("An unexpected error has occurred")
+			}
+			if len(res.Frames) != 1 {
+				t.Errorf("resposne length sould be 1")
+			}
+			if res.Frames[0].Name != "PV:NAME1" {
+				t.Errorf("got %v, want PV:NAME1", res.Frames[0].Name)
 			}
 		})
 	}


### PR DESCRIPTION

The plugin returned a error response without frames if a response from AA has some error. Therefore, it couldn't return frames even if there are some acceptable responses on regex mode.

This PR fixes to return frames even if the response error occurs.