### PR TITLE
ENH: update components to use InlineSwitch and InlineField instead of LegacyForms.Switch

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { DataSourceHttpSettings, InlineSwitch, InlineField } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { LegacyForms } from '@grafana/ui';
 import { AADataSourceOptions } from '../types';
+
+const LABEL_WIDTH = 26;
 
 export type Props = DataSourcePluginOptionsEditorProps<AADataSourceOptions>;
 
@@ -32,14 +33,17 @@ export class ConfigEditor extends PureComponent<Props> {
         />
         <h3 className="page-heading">Misc</h3>
         <div className="gf-form-group">
-          <div className="gf-form">
-            <LegacyForms.Switch
-              checked={options.jsonData.useBackend ?? false}
+          <div className="gf-form-inline">
+            <InlineField
               label="Use Backend"
-              labelClass={'width-13'}
+              labelWidth={LABEL_WIDTH}
               tooltip="Checking this option will enable the data retrieval with backend. The archived data is retrieved and processed on Grafana server, then the data is sent to Grafana client."
-              onChange={this.onUseBEChange}
-            />
+            >
+              <InlineSwitch
+                value={options.jsonData.useBackend ?? false}
+                onChange={this.onUseBEChange}
+              />
+            </InlineField>
           </div>
         </div>
       </>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -164,7 +164,7 @@ export class QueryEditor extends PureComponent<Props, State> {
           >
             PV
           </InlineFormLabel>
-          <div className="max-width-30" style={{ marginRight: '4px' }}>
+          <div className="max-width-30 gf-form-spacing">
             <Autosuggest
               suggestions={pvSuggestions}
               onSuggestionsFetchRequested={this.onPVSuggestionsFetchRequested}
@@ -223,7 +223,7 @@ export class QueryEditor extends PureComponent<Props, State> {
           >
             Operator
           </InlineFormLabel>
-          <div className="max-width-30" style={{ marginRight: '4px' }}>
+          <div className="max-width-30 gf-form-spacing">
             <Autosuggest
               suggestions={oprSuggestions}
               onSuggestionsFetchRequested={this.onOprSuggestionsFetchRequested}
@@ -254,12 +254,11 @@ export class QueryEditor extends PureComponent<Props, State> {
           >
             Stream
           </InlineFormLabel>
-          <div style={{ marginRight: '4px' }}>
-            <InlineSwitch
-              value={query.stream}
-              onChange={this.onStreamChange}
-            />
-          </div>
+          <InlineSwitch
+            value={query.stream}
+            onChange={this.onStreamChange}
+            className="gf-form-spacing"
+          />
           <InlineFormLabel
             width={6}
             className="query-keyword"

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import defaults from 'lodash/defaults';
 import React, { ChangeEvent, PureComponent, KeyboardEvent } from 'react';
-import { InlineFormLabel, LegacyForms } from '@grafana/ui';
+import { InlineFormLabel, InlineSwitch } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import Autosuggest from 'react-autosuggest';
@@ -185,11 +185,19 @@ export class QueryEditor extends PureComponent<Props, State> {
               }}
             />
           </div>
-          <LegacyForms.Switch
-            checked={query.regex}
-            label="Regex"
-            labelClass={'width-7  query-keyword'}
-            tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+          <InlineFormLabel
+            width={7}
+            className="query-keyword"
+            tooltip={
+              <p>
+                Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+              </p>
+            }
+          >
+            Regex
+          </InlineFormLabel>
+          <InlineSwitch
+            value={query.regex}
             onChange={this.onRegexChange}
           />
         </div>
@@ -235,13 +243,23 @@ export class QueryEditor extends PureComponent<Props, State> {
               }}
             />
           </div>
-          <LegacyForms.Switch
-            checked={query.stream}
-            label="Stream"
-            labelClass={'width-7  query-keyword'}
-            tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-            onChange={this.onStreamChange}
-          />
+          <InlineFormLabel
+            width={7}
+            className="query-keyword"
+            tooltip={
+              <p>
+                Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+              </p>
+            }
+          >
+            Stream
+          </InlineFormLabel>
+          <div style={{ marginRight: '4px' }}>
+            <InlineSwitch
+              value={query.stream}
+              onChange={this.onStreamChange}
+            />
+          </div>
           <InlineFormLabel
             width={6}
             className="query-keyword"

--- a/src/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/src/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -44,15 +44,18 @@ exports[`Render should render component 1`] = `
     className="gf-form-group"
   >
     <div
-      className="gf-form"
+      className="gf-form-inline"
     >
-      <Switch$1
-        checked={false}
+      <InlineField
         label="Use Backend"
-        labelClass="width-13"
-        onChange={[Function]}
+        labelWidth={26}
         tooltip="Checking this option will enable the data retrieval with backend. The archived data is retrieved and processed on Grafana server, then the data is sent to Grafana client."
-      />
+      >
+        <Switch
+          onChange={[Function]}
+          value={false}
+        />
+      </InlineField>
     </div>
   </div>
 </Fragment>

--- a/src/components/__snapshots__/QueryEditor.test.tsx.snap
+++ b/src/components/__snapshots__/QueryEditor.test.tsx.snap
@@ -76,12 +76,20 @@ exports[`Render Editor with basic options should render normally 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Regex"
-      labelClass="width-7  query-keyword"
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+        </p>
+      }
+      width={7}
+    >
+      Regex
+    </FormLabel>
+    <Switch
       onChange={[Function]}
-      tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+      value={false}
     />
   </div>
   <div
@@ -180,13 +188,29 @@ exports[`Render Editor with basic options should render normally 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Stream"
-      labelClass="width-7  query-keyword"
-      onChange={[Function]}
-      tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-    />
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+        </p>
+      }
+      width={7}
+    >
+      Stream
+    </FormLabel>
+    <div
+      style={
+        Object {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <Switch
+        onChange={[Function]}
+        value={false}
+      />
+    </div>
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -404,12 +428,20 @@ exports[`Render Editor with basic options should render regex mode 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={true}
-      label="Regex"
-      labelClass="width-7  query-keyword"
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+        </p>
+      }
+      width={7}
+    >
+      Regex
+    </FormLabel>
+    <Switch
       onChange={[Function]}
-      tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+      value={true}
     />
   </div>
   <div
@@ -508,13 +540,29 @@ exports[`Render Editor with basic options should render regex mode 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Stream"
-      labelClass="width-7  query-keyword"
-      onChange={[Function]}
-      tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-    />
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+        </p>
+      }
+      width={7}
+    >
+      Stream
+    </FormLabel>
+    <div
+      style={
+        Object {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <Switch
+        onChange={[Function]}
+        value={false}
+      />
+    </div>
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -730,12 +778,20 @@ exports[`Render Editor with basic options should render with alias pattern 1`] =
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Regex"
-      labelClass="width-7  query-keyword"
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+        </p>
+      }
+      width={7}
+    >
+      Regex
+    </FormLabel>
+    <Switch
       onChange={[Function]}
-      tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+      value={false}
     />
   </div>
   <div
@@ -834,13 +890,29 @@ exports[`Render Editor with basic options should render with alias pattern 1`] =
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Stream"
-      labelClass="width-7  query-keyword"
-      onChange={[Function]}
-      tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-    />
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+        </p>
+      }
+      width={7}
+    >
+      Stream
+    </FormLabel>
+    <div
+      style={
+        Object {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <Switch
+        onChange={[Function]}
+        value={false}
+      />
+    </div>
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -1060,12 +1132,20 @@ exports[`Render Editor with basic options should render with stream 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Regex"
-      labelClass="width-7  query-keyword"
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+        </p>
+      }
+      width={7}
+    >
+      Regex
+    </FormLabel>
+    <Switch
       onChange={[Function]}
-      tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+      value={false}
     />
   </div>
   <div
@@ -1164,13 +1244,29 @@ exports[`Render Editor with basic options should render with stream 1`] = `
         }
       />
     </div>
-    <Switch$1
-      checked={true}
-      label="Stream"
-      labelClass="width-7  query-keyword"
-      onChange={[Function]}
-      tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-    />
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+        </p>
+      }
+      width={7}
+    >
+      Stream
+    </FormLabel>
+    <div
+      style={
+        Object {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <Switch
+        onChange={[Function]}
+        value={true}
+      />
+    </div>
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -1386,12 +1482,20 @@ exports[`Render Editor with basic options should render with top function 1`] = 
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Regex"
-      labelClass="width-7  query-keyword"
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins.
+        </p>
+      }
+      width={7}
+    >
+      Regex
+    </FormLabel>
+    <Switch
       onChange={[Function]}
-      tooltip="Enable/Disable Regex mode. You can select multiple PVs using Regular Expressoins."
+      value={false}
     />
   </div>
   <div
@@ -1490,13 +1594,29 @@ exports[`Render Editor with basic options should render with top function 1`] = 
         }
       />
     </div>
-    <Switch$1
-      checked={false}
-      label="Stream"
-      labelClass="width-7  query-keyword"
-      onChange={[Function]}
-      tooltip="Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved."
-    />
+    <FormLabel
+      className="query-keyword"
+      tooltip={
+        <p>
+          Stream allows to periodically update the data without refreshing the dashboard. The difference data from the last updated values is only retrieved.
+        </p>
+      }
+      width={7}
+    >
+      Stream
+    </FormLabel>
+    <div
+      style={
+        Object {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <Switch
+        onChange={[Function]}
+        value={false}
+      />
+    </div>
     <FormLabel
       className="query-keyword"
       tooltip={

--- a/src/components/__snapshots__/QueryEditor.test.tsx.snap
+++ b/src/components/__snapshots__/QueryEditor.test.tsx.snap
@@ -21,12 +21,7 @@ exports[`Render Editor with basic options should render normally 1`] = `
       PV
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -134,12 +129,7 @@ exports[`Render Editor with basic options should render normally 1`] = `
       Operator
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -199,18 +189,11 @@ exports[`Render Editor with basic options should render normally 1`] = `
     >
       Stream
     </FormLabel>
-    <div
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
-    >
-      <Switch
-        onChange={[Function]}
-        value={false}
-      />
-    </div>
+    <Switch
+      className="gf-form-spacing"
+      onChange={[Function]}
+      value={false}
+    />
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -371,12 +354,7 @@ exports[`Render Editor with basic options should render regex mode 1`] = `
       PV
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -486,12 +464,7 @@ exports[`Render Editor with basic options should render regex mode 1`] = `
       Operator
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -551,18 +524,11 @@ exports[`Render Editor with basic options should render regex mode 1`] = `
     >
       Stream
     </FormLabel>
-    <div
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
-    >
-      <Switch
-        onChange={[Function]}
-        value={false}
-      />
-    </div>
+    <Switch
+      className="gf-form-spacing"
+      onChange={[Function]}
+      value={false}
+    />
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -723,12 +689,7 @@ exports[`Render Editor with basic options should render with alias pattern 1`] =
       PV
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -836,12 +797,7 @@ exports[`Render Editor with basic options should render with alias pattern 1`] =
       Operator
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -901,18 +857,11 @@ exports[`Render Editor with basic options should render with alias pattern 1`] =
     >
       Stream
     </FormLabel>
-    <div
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
-    >
-      <Switch
-        onChange={[Function]}
-        value={false}
-      />
-    </div>
+    <Switch
+      className="gf-form-spacing"
+      onChange={[Function]}
+      value={false}
+    />
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -1077,12 +1026,7 @@ exports[`Render Editor with basic options should render with stream 1`] = `
       PV
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -1190,12 +1134,7 @@ exports[`Render Editor with basic options should render with stream 1`] = `
       Operator
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -1255,18 +1194,11 @@ exports[`Render Editor with basic options should render with stream 1`] = `
     >
       Stream
     </FormLabel>
-    <div
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
-    >
-      <Switch
-        onChange={[Function]}
-        value={true}
-      />
-    </div>
+    <Switch
+      className="gf-form-spacing"
+      onChange={[Function]}
+      value={true}
+    />
     <FormLabel
       className="query-keyword"
       tooltip={
@@ -1427,12 +1359,7 @@ exports[`Render Editor with basic options should render with top function 1`] = 
       PV
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -1540,12 +1467,7 @@ exports[`Render Editor with basic options should render with top function 1`] = 
       Operator
     </FormLabel>
     <div
-      className="max-width-30"
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
+      className="max-width-30 gf-form-spacing"
     >
       <Autosuggest
         alwaysRenderSuggestions={false}
@@ -1605,18 +1527,11 @@ exports[`Render Editor with basic options should render with top function 1`] = 
     >
       Stream
     </FormLabel>
-    <div
-      style={
-        Object {
-          "marginRight": "4px",
-        }
-      }
-    >
-      <Switch
-        onChange={[Function]}
-        value={false}
-      />
-    </div>
+    <Switch
+      className="gf-form-spacing"
+      onChange={[Function]}
+      value={false}
+    />
     <FormLabel
       className="query-keyword"
       tooltip={


### PR DESCRIPTION
This PR updates ConfigEditor and QueryEditor to use `InlineSwitch` and `InlineField` instead of `LegacyForms.Switch`.