### PR TITLE
ENH: debounce the loading of PV names in 200 msec

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@swc/jest": "^0.2.23",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
+    "@types/debounce-promise": "^3.1.6",
     "@types/glob": "^8.0.0",
     "@types/grafana": "github:CorpGlory/types-grafana",
     "@types/jest": "^29.2.2",
@@ -57,8 +58,6 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "mathjs": "^11.7.0",
-    "ms": "^2.1.3",
     "prettier": "^2.5.0",
     "react-test-renderer": "18.2.0",
     "replace-in-file-webpack-plugin": "^1.0.6",
@@ -69,7 +68,6 @@
     "ts-node": "^10.5.0",
     "tsconfig-paths": "^4.1.0",
     "typescript": "^4.4.0",
-    "uuid": "^9.0.0",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
     "webpack-livereload-plugin": "^3.0.2"
@@ -80,7 +78,11 @@
     "@grafana/data": "9.4.7",
     "@grafana/runtime": "9.4.7",
     "@grafana/ui": "9.4.7",
+    "debounce-promise": "^3.1.2",
+    "mathjs": "^11.7.0",
+    "ms": "^2.1.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,4 +1,5 @@
 import defaults from 'lodash/defaults';
+import debounce from 'debounce-promise';
 import React, { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { components } from "react-select";
 import { InlineFormLabel, InlineSwitch, Select, AsyncSelect, InputActionMeta } from '@grafana/ui';
@@ -21,6 +22,7 @@ const Input = (props: any) => <components.Input {...props} isHidden={false} />;
 
 export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props): JSX.Element => {
   const defaultOption = query.target ? toOption(query.target) : undefined;
+
 
   // These states are used to control PV name suggestions with AsyncSelect.
   // The following web pages were consulted.
@@ -107,6 +109,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
       return suggestions;
     });
   }
+  const debounceLoadSuggestions = debounce((query: string) => loadPVSuggestions(query), 200);
 
   const query_ = defaults(query, defaultQuery);
   const aliasInputStyle = query_.aliasPattern ? { color: colorYellow } : {};
@@ -138,7 +141,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
               Input
             }}
             onInputChange={onInputChange}
-            loadOptions={loadPVSuggestions}
+            loadOptions={debounceLoadSuggestions}
             onChange={onPVChange}
             placeholder="PV name"
             key={JSON.stringify(optionValue)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,6 +2697,11 @@
   dependencies:
     "@types/d3-color" "*"
 
+"@types/debounce-promise@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@types/debounce-promise/-/debounce-promise-3.1.6.tgz#873e838574011095ed0debf73eed3538e1261d75"
+  integrity sha512-DowqK95aku+OxMCeG2EQSeXeGeE8OCwLpMsUfIbP7hMF8Otj8eQXnzpwdtIKV+UqQBtkMcF6vbi4Otbh8P/wmg==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -4592,6 +4597,11 @@ dayjs@^1.10.4:
   version "1.11.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
+debounce-promise@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/debounce-promise/-/debounce-promise-3.1.2.tgz#320fb8c7d15a344455cd33cee5ab63530b6dc7c5"
+  integrity sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==
 
 debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
This PR debounces the loading of PV names in 200 msec when the PV name is entered in the query editor.

It is expected that this will reduce the number of requests made to the Archiver Appliance server.