### PR TITLE
ENH: fix initial capacity for stream queries

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -171,6 +171,7 @@ export class DataSource extends DataSourceWithBackend<AAQuery, AADataSourceOptio
         from,
         to,
         interval,
+        maxDataPoints,
       };
     });
 

--- a/src/responseParse.ts
+++ b/src/responseParse.ts
@@ -48,11 +48,11 @@ export function responseParse(responses: AADataQueryResponse[], target: TargetQu
     if (stream) {
       // for stream query
       // extrapolation is performed if there is no sample point in the margin
-      const stream_last_time = to_msec - STREAM_FROM_MARGIN_MS - 1;
-      if (newRow[0] > stream_last_time) {
+      const streamLastTime = to_msec - STREAM_FROM_MARGIN_MS - 1;
+      if (newRow[0] > streamLastTime) {
         return dataframe;
       }
-      newRow[0] = stream_last_time;
+      newRow[0] = streamLastTime;
     } else {
       // for normal query
       newRow[0] = to_msec;

--- a/src/specs/datasource.test.ts
+++ b/src/specs/datasource.test.ts
@@ -1246,6 +1246,60 @@ describe('Archiverappliance Datasource', () => {
         const timesArray = dataFrame.fields[0].values.toArray();
         const valArray = dataFrame.fields[1].values.toArray();
 
+        expect(valArray).toEqual([0, 1, 2, 1, 2, 1, 2]);
+        expect(timesArray).toHaveLength(7);
+
+        const diff = timesArray[6] - timesArray[4];
+        expect(diff).toBeGreaterThanOrEqual(2000);
+        expect(diff).toBeLessThan(4000);
+
+        done();
+      });
+    }, 10000);
+
+    it('should return stream data with strmInt while without strmCap but maxDatapoints is less than initial datapoints', (done) => {
+      fetchMock.mockImplementation((request) => {
+        const from_str = unescape(split(request.url, /from=(.*Z)&to/)[1]);
+        const to_str = unescape(split(request.url, /to=(.*Z)/)[1]);
+
+        const from_ms = new Date(from_str).getTime();
+        const to_ms = new Date(to_str).getTime();
+
+        return from([
+          {
+            data: [
+              {
+                meta: { name: 'PV', PREC: '0' },
+                data: [
+                  { millis: from_ms - 1, val: 0 },
+                  { millis: Math.floor((from_ms + to_ms) / 2), val: 1 },
+                  { millis: to_ms, val: 2 },
+                ],
+              },
+            ],
+          },
+        ]);
+      });
+
+      const now = Date.now();
+      const query = {
+        targets: [{ target: 'PV', refId: 'A', stream: true, strmInt: '3000' }],
+        range: { from: new Date(now - 1000 * 1000), to: new Date(now) },
+        rangeRaw: { to: 'now' },
+        maxDataPoints: 1,
+        intervalMs: 1000,
+      } as unknown as DataQueryRequest<AAQuery>;
+
+      const d = ds.query(query).pipe(take(3), toArray());
+
+      d.subscribe((results: any[]) => {
+        expect(results).toHaveLength(3);
+        const result = results[2];
+        expect(result.data).toHaveLength(1);
+        const dataFrame: DataFrame = result.data[0];
+        const timesArray = dataFrame.fields[0].values.toArray();
+        const valArray = dataFrame.fields[1].values.toArray();
+
         expect(valArray).toEqual([2, 1, 2]);
         expect(timesArray).toHaveLength(3);
 
@@ -1300,10 +1354,10 @@ describe('Archiverappliance Datasource', () => {
         const timesArray = dataFrame.fields[0].values;
         const valArray = dataFrame.fields[1].values.toArray();
 
-        expect(valArray).toEqual([2, 1, 2]);
-        expect(timesArray).toHaveLength(3);
+        expect(valArray).toEqual([0, 1, 2, 1, 2, 1, 2]);
+        expect(timesArray).toHaveLength(7);
 
-        const diff = timesArray[2] - timesArray[0];
+        const diff = timesArray[6] - timesArray[4];
         expect(diff).toBeGreaterThanOrEqual(2000);
         expect(diff).toBeLessThan(4000);
 

--- a/src/streamQuery.ts
+++ b/src/streamQuery.ts
@@ -162,7 +162,8 @@ function mergeResToCirFrames(
 
 function createStreamFrame(target: TargetQuery, dataFrame: DataFrame) {
   const c = parseInt(target.strmCap, 10);
-  const cap = dataFrame.refId ? c || dataFrame.length : dataFrame.length;
+  const defaultCap = target.maxDataPoints > dataFrame.length ? target.maxDataPoints : dataFrame.length;
+  const cap = dataFrame.refId ? c || defaultCap : defaultCap;
 
   const new_frame = new CircularDataFrame({
     append: 'tail',

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface TargetQuery {
   from: Date;
   to: Date;
   interval: string;
+  maxDataPoints: number;
 }
 
 export interface AADataQueryData {


### PR DESCRIPTION
This PR fixes the initial capacity for stream queries. The initial capacity will be greater than maxDataPoints if the capacity is not explicitly defined.