### PR TITLE
ENH: add enum response to the fieldName function for SEVR and STAT

### DIFF
--- a/pkg/archiverappliance/pbparse_test.go
+++ b/pkg/archiverappliance/pbparse_test.go
@@ -350,6 +350,91 @@ func TestParseArrayData(t *testing.T) {
 }
 
 func TestParseDataWithSeverity(t *testing.T) {
+	ARCHIVER_FLOAT_PRECISION := 1e-18
+	var tests = []struct {
+		name      string
+		field     models.FieldName
+		length    int
+		firstVal  float64
+		firstDate time.Time
+		lastVal   float64
+		lastDate  time.Time
+	}{
+		{
+			name:      "SCALAR_BYTE_sampledata",
+			field:     models.FIELD_NAME_SEVR,
+			length:    366,
+			firstVal:  0.0,
+			lastVal:   0.0,
+			firstDate: time.Date(2012, 1, 1, 9, 43, 37, 0, time.UTC),
+			lastDate:  time.Date(2012, 12, 31, 9, 43, 37, 0, time.UTC),
+		},
+		{
+			name:      "SCALAR_BYTE_sampledata",
+			field:     models.FIELD_NAME_STAT,
+			length:    366,
+			firstVal:  0.0,
+			lastVal:   0.0,
+			firstDate: time.Date(2012, 1, 1, 9, 43, 37, 0, time.UTC),
+			lastDate:  time.Date(2012, 12, 31, 9, 43, 37, 0, time.UTC),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			f, err := os.Open("../test_data/pb/" + testCase.name)
+
+			if err != nil {
+				t.Fatalf("Failed to load test data: %v", err)
+			}
+
+			defer f.Close()
+
+			sD, err := archiverPBSingleQueryParser(f, testCase.field, 1000, false)
+			if err != nil {
+				t.Fatalf("Failed to parse the data: %v", err)
+			}
+
+			if sD.Name != testCase.name {
+				t.Fatalf("Names differ - Wanted: %v Got: %v", testCase.name, sD.Name)
+			}
+
+			if sD.PVname != testCase.name {
+				t.Fatalf("Names differ - Wanted: %v Got: %v", testCase.name, sD.Name)
+			}
+
+			v, ok := sD.Values.(*models.Scalars)
+
+			if !ok {
+				t.Fatalf("Single data type is diffrent")
+			}
+
+			resultLength := len(v.Times)
+			if resultLength != testCase.length {
+				t.Fatalf("Lengths differ - Wanted: %v Got: %v", testCase.length, resultLength)
+			}
+
+			if math.Abs(*v.Values[0]-testCase.firstVal) > ARCHIVER_FLOAT_PRECISION {
+				t.Fatalf("First values differ - Wanted: %v Got: %v", testCase.firstVal, v.Values[0])
+			}
+			if !v.Times[0].Equal(testCase.firstDate) {
+				t.Fatalf("Fisrt date differ - Wanted: %v Got: %v", v.Times[0], testCase.firstDate)
+			}
+
+			lastIndex := resultLength - 1
+
+			if math.Abs(*v.Values[lastIndex]-testCase.lastVal) > ARCHIVER_FLOAT_PRECISION {
+				t.Fatalf("last values differ - Wanted: %v Got: %v", testCase.lastVal, v.Values[lastIndex])
+			}
+
+			if !v.Times[lastIndex].Equal(testCase.lastDate) {
+				t.Fatalf("Last date differ - Wanted: %v Got: %v", v.Times[lastIndex], testCase.lastDate)
+			}
+		})
+	}
+}
+
+func TestParseDataWithSeverityEnum(t *testing.T) {
 	var tests = []struct {
 		name      string
 		field     models.FieldName
@@ -361,7 +446,7 @@ func TestParseDataWithSeverity(t *testing.T) {
 	}{
 		{
 			name:      "SCALAR_BYTE_sampledata",
-			field:     models.FIELD_NAME_SEVR,
+			field:     models.FIELD_NAME_SEVR_AS_ENUM,
 			length:    366,
 			firstVal:  0,
 			lastVal:   0,
@@ -370,7 +455,7 @@ func TestParseDataWithSeverity(t *testing.T) {
 		},
 		{
 			name:      "SCALAR_BYTE_sampledata",
-			field:     models.FIELD_NAME_STAT,
+			field:     models.FIELD_NAME_STAT_AS_ENUM,
 			length:    366,
 			firstVal:  0,
 			lastVal:   0,

--- a/pkg/archiverappliance/pbparse_test.go
+++ b/pkg/archiverappliance/pbparse_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/sasaki77/archiverappliance-datasource/pkg/models"
 )
 
@@ -349,22 +350,21 @@ func TestParseArrayData(t *testing.T) {
 }
 
 func TestParseDataWithSeverity(t *testing.T) {
-	ARCHIVER_FLOAT_PRECISION := 1e-18
 	var tests = []struct {
 		name      string
 		field     models.FieldName
 		length    int
-		firstVal  float64
+		firstVal  data.EnumItemIndex
 		firstDate time.Time
-		lastVal   float64
+		lastVal   data.EnumItemIndex
 		lastDate  time.Time
 	}{
 		{
 			name:      "SCALAR_BYTE_sampledata",
 			field:     models.FIELD_NAME_SEVR,
 			length:    366,
-			firstVal:  0.0,
-			lastVal:   0.0,
+			firstVal:  0,
+			lastVal:   0,
 			firstDate: time.Date(2012, 1, 1, 9, 43, 37, 0, time.UTC),
 			lastDate:  time.Date(2012, 12, 31, 9, 43, 37, 0, time.UTC),
 		},
@@ -372,8 +372,8 @@ func TestParseDataWithSeverity(t *testing.T) {
 			name:      "SCALAR_BYTE_sampledata",
 			field:     models.FIELD_NAME_STAT,
 			length:    366,
-			firstVal:  0.0,
-			lastVal:   0.0,
+			firstVal:  0,
+			lastVal:   0,
 			firstDate: time.Date(2012, 1, 1, 9, 43, 37, 0, time.UTC),
 			lastDate:  time.Date(2012, 12, 31, 9, 43, 37, 0, time.UTC),
 		},
@@ -402,7 +402,7 @@ func TestParseDataWithSeverity(t *testing.T) {
 				t.Fatalf("Names differ - Wanted: %v Got: %v", testCase.name, sD.Name)
 			}
 
-			v, ok := sD.Values.(*models.Scalars)
+			v, ok := sD.Values.(*models.Enums)
 
 			if !ok {
 				t.Fatalf("Single data type is diffrent")
@@ -413,7 +413,7 @@ func TestParseDataWithSeverity(t *testing.T) {
 				t.Fatalf("Lengths differ - Wanted: %v Got: %v", testCase.length, resultLength)
 			}
 
-			if math.Abs(*v.Values[0]-testCase.firstVal) > ARCHIVER_FLOAT_PRECISION {
+			if v.Values[0] != testCase.firstVal {
 				t.Fatalf("First values differ - Wanted: %v Got: %v", testCase.firstVal, v.Values[0])
 			}
 
@@ -422,7 +422,7 @@ func TestParseDataWithSeverity(t *testing.T) {
 			}
 
 			lastIndex := resultLength - 1
-			if math.Abs(*v.Values[lastIndex]-testCase.lastVal) > ARCHIVER_FLOAT_PRECISION {
+			if v.Values[lastIndex] != testCase.lastVal {
 				t.Fatalf("last values differ - Wanted: %v Got: %v", testCase.lastVal, v.Values[lastIndex])
 			}
 

--- a/pkg/models/enums.go
+++ b/pkg/models/enums.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+type Enums struct {
+	Times      []time.Time
+	Values     []data.EnumItemIndex
+	EnumConfig data.EnumFieldConfig
+}
+
+func NewEnums(length int) *Enums {
+	return &Enums{
+		Times:  make([]time.Time, 0, length),
+		Values: make([]data.EnumItemIndex, 0, length),
+	}
+}
+
+func NewSevirityEnums(length int) *Enums {
+	c := data.EnumFieldConfig{
+		Text:  []string{"NO_ALARM", "MINOR", "MAJOR", "INVALID"},
+		Color: []string{"rgb(86, 166, 75)", "rgb(255, 120, 10)", "rgb(224, 47, 68)", "rgb(163, 82, 204)"},
+	}
+
+	return &Enums{
+		Times:      make([]time.Time, 0, length),
+		Values:     make([]data.EnumItemIndex, 0, length),
+		EnumConfig: c,
+	}
+}
+
+func NewStatusEnums(length int) *Enums {
+	c := data.EnumFieldConfig{
+		Text: []string{"NO_ALARM", "READ", "WRITE", "HIHI", "HIGH", "LOLO", "LOW", "STATE", "COS", "COMM", "TIMEOUT", "HWLIMIT", "CALC", "SCAN", "LINK", "SOFT", "BAD_SUB", "UDF", "DISABLE", "SIMM", "READ_ACCESS", "WRITE_ACCESS"},
+	}
+
+	return &Enums{
+		Times:      make([]time.Time, 0, length),
+		Values:     make([]data.EnumItemIndex, 0, length),
+		EnumConfig: c,
+	}
+}
+
+func (v *Enums) Append(val int16, t time.Time) {
+	v.Values = append(v.Values, data.EnumItemIndex(val))
+	v.Times = append(v.Times, t)
+}
+
+func (v *Enums) ToFields(pvname string, name string, format FormatOption) []*data.Field {
+	// ToFields doesn't use FormatOption in Enums for now
+
+	var fields []*data.Field
+
+	//add the time dimension
+	fields = append(fields, data.NewField("time", nil, v.Times))
+
+	// add values
+	labels := make(data.Labels, 1)
+	labels["pvname"] = pvname
+
+	valueField := data.NewField(name, labels, v.Values)
+	tc := &data.FieldTypeConfig{Enum: &v.EnumConfig}
+	valueField.Config = &data.FieldConfig{DisplayName: name, TypeConfig: tc}
+	fields = append(fields, valueField)
+
+	return fields
+}
+
+func (v *Enums) Extrapolation(t time.Time) {
+	if len(v.Values) == 0 {
+		return
+	}
+	v.Values = append(v.Values, v.Values[len(v.Values)-1])
+	v.Times = append(v.Times, t)
+}

--- a/pkg/models/functions.go
+++ b/pkg/models/functions.go
@@ -35,9 +35,11 @@ const (
 type FieldName string
 
 const (
-	FIELD_NAME_VAL  FieldName = "VAL"
-	FIELD_NAME_SEVR FieldName = "SEVR"
-	FIELD_NAME_STAT FieldName = "STAT"
+	FIELD_NAME_VAL          FieldName = "VAL"
+	FIELD_NAME_SEVR         FieldName = "SEVR"
+	FIELD_NAME_STAT         FieldName = "STAT"
+	FIELD_NAME_SEVR_AS_ENUM FieldName = "SEVR as Enum"
+	FIELD_NAME_STAT_AS_ENUM FieldName = "STAT as Enum"
 )
 
 func (qm ArchiverQueryModel) PickFuncsByCategories(categories []FunctionCategory) []FunctionDescriptorQueryModel {

--- a/pkg/models/testhelpers.go
+++ b/pkg/models/testhelpers.go
@@ -78,6 +78,24 @@ func SingleDataCompareHelper(result []*SingleData, wanted []*SingleData, t *test
 					t.Errorf("Values at index %v do not match, Wanted %v, got %v", idx, wantedv.Values[idx], resultv.Values[idx])
 				}
 			}
+		case *Enums:
+			wantedv := wanted[udx].Values.(*Enums)
+			if len(wantedv.Times) != len(resultv.Times) {
+				t.Errorf("Input and output arrays' times differ in length. Wanted %v, got %v", len(wantedv.Times), len(resultv.Times))
+				return
+			}
+			if len(wantedv.Values) != len(resultv.Values) {
+				t.Errorf("Input and output arrays' values differ in length. Wanted %v, got %v", len(wantedv.Values), len(resultv.Values))
+				return
+			}
+			for idx := range wantedv.Values {
+				if resultv.Times[idx] != wantedv.Times[idx] {
+					t.Errorf("Times at index %v do not match, Wanted %v, got %v", idx, wantedv.Times[idx], resultv.Times[idx])
+				}
+				if resultv.Values[idx] != wantedv.Values[idx] {
+					t.Errorf("Values at index %v do not match, Wanted %v, got %v", idx, wantedv.Values[idx], resultv.Values[idx])
+				}
+			}
 		default:
 			t.Fatalf("Response Values are invalid")
 		}

--- a/src/aafunc.ts
+++ b/src/aafunc.ts
@@ -228,7 +228,7 @@ addFuncDef({
 addFuncDef({
   name: 'fieldName',
   category: 'Options',
-  params: [{ name: 'name', type: 'string', options: ['VAL', 'SEVR', 'STAT'] }],
+  params: [{ name: 'name', type: 'string', options: ['VAL', 'SEVR', 'STAT', 'SEVR as Enum', 'STAT as Enum'] }],
   defaultParams: ['SEVR'],
 });
 


### PR DESCRIPTION
This PR adds the `SEVR as Enum` and `STAT as Enum` options to the `fieldName` function.

The example of displays are as follows. Enum data can be displayed as text such as `NO_ALARM`.

![image](https://github.com/user-attachments/assets/4c2ed44b-6012-4e9b-916b-c875733501cb)
