### PR TITLE
MAINT: fix to use DisplayNameFromDS

### DIFF
--- a/pkg/archiverappliance/query_test.go
+++ b/pkg/archiverappliance/query_test.go
@@ -133,7 +133,7 @@ func TestQuery(t *testing.T) {
 											"pvname": "PV:NAME2",
 										},
 										Config: &data.FieldConfig{
-											DisplayName: "NAME2:PV",
+											DisplayNameFromDS: "NAME2:PV",
 										},
 									},
 								},
@@ -152,7 +152,7 @@ func TestQuery(t *testing.T) {
 											"pvname": "PV:NAME1",
 										},
 										Config: &data.FieldConfig{
-											DisplayName: "NAME1:PV",
+											DisplayNameFromDS: "NAME1:PV",
 										},
 									},
 								},
@@ -207,7 +207,7 @@ func TestQuery(t *testing.T) {
 											"pvname": "PV:NAME1",
 										},
 										Config: &data.FieldConfig{
-											DisplayName: "NAME1:PV",
+											DisplayNameFromDS: "NAME1:PV",
 										},
 									},
 								},
@@ -226,7 +226,7 @@ func TestQuery(t *testing.T) {
 											"pvname": "PV:NAME2",
 										},
 										Config: &data.FieldConfig{
-											DisplayName: "NAME2:PV",
+											DisplayNameFromDS: "NAME2:PV",
 										},
 									},
 								},
@@ -281,7 +281,7 @@ func TestQuery(t *testing.T) {
 											"pvname": "string",
 										},
 										Config: &data.FieldConfig{
-											DisplayName: "string",
+											DisplayNameFromDS: "string",
 										},
 									},
 								},
@@ -324,8 +324,8 @@ func TestQuery(t *testing.T) {
 				if vf.Labels["pvname"] != outvf.Labels["pvname"] {
 					t.Errorf("got %v, want %v", vf.Labels["pvname"], outvf.Labels["pvname"])
 				}
-				if vf.Config.DisplayName != outvf.Config.DisplayName {
-					t.Errorf("got %v, want %v", vf.Config.DisplayName, outvf.Config.DisplayName)
+				if vf.Config.DisplayNameFromDS != outvf.Config.DisplayNameFromDS {
+					t.Errorf("got %v, want %v", vf.Config.DisplayNameFromDS, outvf.Config.DisplayNameFromDS)
 				}
 				if vf.Len() != 3 {
 					t.Errorf("got %v, want %v", vf.Len(), 3)

--- a/pkg/models/arrays.go
+++ b/pkg/models/arrays.go
@@ -70,7 +70,7 @@ func (v *Arrays) makeDtSpaceFields(pvname string, name string) []*data.Field {
 	labels["pvname"] = pvname
 
 	valueField := data.NewField(name, labels, vals)
-	valueField.Config = &data.FieldConfig{DisplayName: name}
+	valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
 	fields = append(fields, valueField)
 
 	return fields
@@ -94,7 +94,7 @@ func (v *Arrays) makeIndexFields(pvname string) []*data.Field {
 
 		n := v.Times[idx].Local().Format("2006-01-02T15:04:05.000Z07:00")
 		valueField := data.NewField(n, labels, datapoint[0:dataLen])
-		valueField.Config = &data.FieldConfig{DisplayName: n}
+		valueField.Config = &data.FieldConfig{DisplayNameFromDS: n}
 		fields = append(fields, valueField)
 	}
 
@@ -115,7 +115,7 @@ func (v *Arrays) makeTimeseriesFields(pvname string, name string) []*data.Field 
 
 		n := fmt.Sprintf("%s[%d]", name, idx)
 		valueField := data.NewField(n, labels, datapoint)
-		valueField.Config = &data.FieldConfig{DisplayName: n}
+		valueField.Config = &data.FieldConfig{DisplayNameFromDS: n}
 		fields = append(fields, valueField)
 	}
 

--- a/pkg/models/enums.go
+++ b/pkg/models/enums.go
@@ -63,7 +63,7 @@ func (v *Enums) ToFields(pvname string, name string, format FormatOption) []*dat
 
 	valueField := data.NewField(name, labels, v.Values)
 	tc := &data.FieldTypeConfig{Enum: &v.EnumConfig}
-	valueField.Config = &data.FieldConfig{DisplayName: name, TypeConfig: tc}
+	valueField.Config = &data.FieldConfig{DisplayNameFromDS: name, TypeConfig: tc}
 	fields = append(fields, valueField)
 
 	return fields

--- a/pkg/models/scalars.go
+++ b/pkg/models/scalars.go
@@ -52,7 +52,7 @@ func (v *Scalars) ToFields(pvname string, name string, format FormatOption) []*d
 	labels["pvname"] = pvname
 
 	valueField := data.NewField(name, labels, v.Values)
-	valueField.Config = &data.FieldConfig{DisplayName: name}
+	valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
 	fields = append(fields, valueField)
 
 	return fields

--- a/pkg/models/singledata_test.go
+++ b/pkg/models/singledata_test.go
@@ -99,8 +99,8 @@ func TestToFrameScalar(t *testing.T) {
 			if result.Fields[0].Len() != testCase.dataSize {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
-			if testCase.name != result.Fields[1].Config.DisplayName {
-				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayName, testCase.name)
+			if testCase.name != result.Fields[1].Config.DisplayNameFromDS {
+				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayNameFromDS, testCase.name)
 			}
 			if testCase.pvname != result.Fields[1].Labels["pvname"] {
 				t.Errorf("got %v, want %v", result.Fields[1].Labels["pvname"], testCase.pvname)
@@ -154,8 +154,8 @@ func TestToFrameString(t *testing.T) {
 			if result.Fields[0].Len() != testCase.dataSize {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
-			if testCase.name != result.Fields[1].Config.DisplayName {
-				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayName, testCase.name)
+			if testCase.name != result.Fields[1].Config.DisplayNameFromDS {
+				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayNameFromDS, testCase.name)
 			}
 			if testCase.pvname != result.Fields[1].Labels["pvname"] {
 				t.Errorf("got %v, want %v", result.Fields[1].Labels["pvname"], testCase.pvname)
@@ -216,8 +216,8 @@ func TestToFrameArray(t *testing.T) {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
 			for idx, v := range result.Fields[1:] {
-				if testCase.fieldNames[idx] != v.Config.DisplayName {
-					t.Errorf("got %v, want %v", v.Config.DisplayName, testCase.fieldNames[idx])
+				if testCase.fieldNames[idx] != v.Config.DisplayNameFromDS {
+					t.Errorf("got %v, want %v", v.Config.DisplayNameFromDS, testCase.fieldNames[idx])
 				}
 				if testCase.pvname != v.Labels["pvname"] {
 					t.Errorf("got %v, want %v", v.Labels["pvname"], testCase.pvname)
@@ -287,8 +287,8 @@ func TestToFrameDtSpaceArray(t *testing.T) {
 				}
 			}
 			for idx, v := range result.Fields[1:] {
-				if testCase.fieldNames[idx] != v.Config.DisplayName {
-					t.Errorf("got %v, want %v", v.Config.DisplayName, testCase.fieldNames[idx])
+				if testCase.fieldNames[idx] != v.Config.DisplayNameFromDS {
+					t.Errorf("got %v, want %v", v.Config.DisplayNameFromDS, testCase.fieldNames[idx])
 				}
 				if testCase.pvname != v.Labels["pvname"] {
 					t.Errorf("got %v, want %v", v.Labels["pvname"], testCase.pvname)
@@ -354,8 +354,8 @@ func TestToFrameIndexArray(t *testing.T) {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
 			for idx, v := range result.Fields[1:] {
-				if testCase.fieldNames[idx] != v.Config.DisplayName {
-					t.Errorf("got %v, want %v", v.Config.DisplayName, testCase.fieldNames[idx])
+				if testCase.fieldNames[idx] != v.Config.DisplayNameFromDS {
+					t.Errorf("got %v, want %v", v.Config.DisplayNameFromDS, testCase.fieldNames[idx])
 				}
 				if testCase.pvname != v.Labels["pvname"] {
 					t.Errorf("got %v, want %v", v.Labels["pvname"], testCase.pvname)
@@ -421,8 +421,8 @@ func TestToFrameIndexArrayInJST(t *testing.T) {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
 			for idx, v := range result.Fields[1:] {
-				if testCase.fieldNames[idx] != v.Config.DisplayName {
-					t.Errorf("got %v, want %v", v.Config.DisplayName, testCase.fieldNames[idx])
+				if testCase.fieldNames[idx] != v.Config.DisplayNameFromDS {
+					t.Errorf("got %v, want %v", v.Config.DisplayNameFromDS, testCase.fieldNames[idx])
 				}
 				if testCase.pvname != v.Labels["pvname"] {
 					t.Errorf("got %v, want %v", v.Labels["pvname"], testCase.pvname)
@@ -483,8 +483,8 @@ func TestToFrameEnum(t *testing.T) {
 			if result.Fields[0].Len() != testCase.dataSize {
 				t.Errorf("got %d, want %d", result.Fields[0].Len(), testCase.dataSize)
 			}
-			if testCase.name != result.Fields[1].Config.DisplayName {
-				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayName, testCase.name)
+			if testCase.name != result.Fields[1].Config.DisplayNameFromDS {
+				t.Errorf("got %v, want %v", result.Fields[1].Config.DisplayNameFromDS, testCase.name)
 			}
 			if testCase.pvname != result.Fields[1].Labels["pvname"] {
 				t.Errorf("got %v, want %v", result.Fields[1].Labels["pvname"], testCase.pvname)

--- a/pkg/models/strings.go
+++ b/pkg/models/strings.go
@@ -36,7 +36,7 @@ func (v *Strings) ToFields(pvname string, name string, format FormatOption) []*d
 	labels["pvname"] = pvname
 
 	valueField := data.NewField(name, labels, v.Values)
-	valueField.Config = &data.FieldConfig{DisplayName: name}
+	valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
 	fields = append(fields, valueField)
 
 	return fields


### PR DESCRIPTION
Source code of `field_config` for Grafana fields says that `DisplayName` should not be used from a data source. Use `DisplayNameFromDS` instead.