### PR TITLE
BUG: fix to handle an empty response in pb parser

### DIFF
--- a/pkg/archiverappliance/pbparse_test.go
+++ b/pkg/archiverappliance/pbparse_test.go
@@ -580,6 +580,21 @@ func TestParseSevInvalidData(t *testing.T) {
 	}
 }
 
+func TestParseEmptyData(t *testing.T) {
+	f, err := os.Open("../test_data/pb/empty_data")
+
+	if err != nil {
+		t.Fatalf("Failed to load test data: %v", err)
+	}
+
+	defer f.Close()
+
+	_, err = archiverPBSingleQueryParser(f, models.FIELD_NAME_VAL, 1000, false)
+	if err != errEmptyResponse {
+		t.Fatalf("parser should return response empty error: %v", err)
+	}
+}
+
 func BenchmarkPBparseOneday(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
As mentioned previously (#102), the Archiver Appliance returns an empty response. This PR fixes the PB parser to handle an empty response.