### PR TITLE
DEP: migrate from deprecated UI components

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@emotion/css": "^11.13.5",
     "@grafana/data": "^12.0.2",
     "@grafana/plugin-e2e": "^2.1.7",
+    "@grafana/plugin-ui": "^0.10.7",
     "@grafana/runtime": "^12.0.2",
     "@grafana/schema": "^12.0.2",
     "@grafana/ui": "^12.0.2",

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,10 +1,11 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { DataSourceHttpSettings, InlineSwitch, InlineField, Select } from '@grafana/ui';
-import { DataSourcePluginOptionsEditorProps, toOption, SelectableValue } from '@grafana/data';
+import { DataSourceHttpSettings, InlineSwitch, InlineField, Combobox, ComboboxOption } from '@grafana/ui';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { AADataSourceOptions, operatorList } from '../types';
+import { toComboboxOption } from './utils';
 
 const LABEL_WIDTH = 26;
-const operatorOptions: Array<SelectableValue<string>> = operatorList.map(toOption);
+const operatorOptions: Array<ComboboxOption<string>> = operatorList.map(toComboboxOption);
 
 export type Props = DataSourcePluginOptionsEditorProps<AADataSourceOptions>;
 
@@ -22,7 +23,7 @@ export class ConfigEditor extends PureComponent<Props> {
     onOptionsChange({ ...options, jsonData });
   };
 
-  onOperatorChange = (option: SelectableValue) => {
+  onOperatorChange = (option: ComboboxOption) => {
     const { onOptionsChange, options } = this.props;
     const jsonData = {
       ...options.jsonData,
@@ -97,7 +98,7 @@ export class ConfigEditor extends PureComponent<Props> {
             </p>
           }
         >
-          <Select
+          <Combobox
             value={options.jsonData.defaultOperator}
             options={operatorOptions}
             onChange={this.onOperatorChange}

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,10 +1,19 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { DataSourceHttpSettings, InlineSwitch, InlineField, Combobox, ComboboxOption } from '@grafana/ui';
+import { Input, Field, Label, Icon, Tooltip, Combobox, ComboboxOption, Divider, Switch, Stack } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { AADataSourceOptions, operatorList } from '../types';
 import { toComboboxOption } from './utils';
+import {
+  ConfigSection,
+  ConnectionSettings,
+  Auth,
+  AdvancedHttpSettings,
+  convertLegacyAuthProps,
+  EditorStack,
+  ConfigSubSection,
+} from '@grafana/plugin-ui';
 
-const LABEL_WIDTH = 26;
+//const LABEL_WIDTH = 26;
 const operatorOptions: Array<ComboboxOption<string>> = operatorList.map(toComboboxOption);
 
 export type Props = DataSourcePluginOptionsEditorProps<AADataSourceOptions>;
@@ -64,77 +73,142 @@ export class ConfigEditor extends PureComponent<Props> {
 
     return (
       <>
-        <DataSourceHttpSettings
-          defaultUrl="http://localhost:17668/retrieval"
-          dataSourceConfig={options}
-          onChange={onOptionsChange}
+        <ConnectionSettings config={options} onChange={onOptionsChange} />
+
+        <Divider spacing={4} />
+
+        <Auth
+          {...convertLegacyAuthProps({
+            config: options,
+            onChange: onOptionsChange,
+          })}
         />
-        <h3 className="page-heading">Misc</h3>
-        <InlineField
-          label="Use Backend"
-          labelWidth={LABEL_WIDTH}
-          tooltip="Checking this option will enable the data retrieval with backend. The archived data is retrieved and processed on Grafana server, then the data is sent to Grafana client."
-          interactive={true}
-        >
-          <InlineSwitch value={options.jsonData.useBackend ?? false} onChange={this.onUseBEChange} />
-        </InlineField>
-        <InlineField
-          label="Default Operator"
-          labelWidth={LABEL_WIDTH}
-          interactive={true}
-          tooltip={
-            <p>
-              Controls processing of data during data retrieval. Refer{' '}
-              <a
-                href="https://epicsarchiver.readthedocs.io/en/latest/user/userguide.html#processing-of-data"
-                target="_blank"
-                rel="noopener noreferrer"
+
+        <Divider spacing={4} />
+
+        <ConfigSection title="Advanced settings" isCollapsible>
+          <Stack gap={3} direction="column">
+            <AdvancedHttpSettings config={options} onChange={onOptionsChange} />
+            <ConfigSubSection title="Data Retrieval Options">
+              <Field
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>Use Backend</span>
+                      <Tooltip
+                        content={
+                          <span>
+                            Checking this option will enable the data retrieval with backend. The archived data is
+                            retrieved and processed on Grafana server, then the data is sent to Grafana client.
+                          </span>
+                        }
+                      >
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
               >
-                Archiver Appliance User Guide
-              </a>{' '}
-              about processing of data. Special operator <code>raw</code> and <code>last</code> are also available.{' '}
-              <code>raw</code> allows to retrieve the data without processing. <code>last</code> allows to retrieve the
-              last data in the specified time range.
-            </p>
-          }
-        >
-          <Combobox
-            value={options.jsonData.defaultOperator}
-            options={operatorOptions}
-            onChange={this.onOperatorChange}
-            placeholder="mean"
-          />
-        </InlineField>
-        <InlineField
-          label="Hide Invalid"
-          labelWidth={LABEL_WIDTH}
-          interactive={true}
-          tooltip={<p>Hide sample data whose severity is invalid with a null value.</p>}
-        >
-          <InlineSwitch value={options.jsonData.hideInvalid ?? false} onChange={this.onHideInvalidChange} />
-        </InlineField>
-        <InlineField
-          label="Use live feature (Alpha)"
-          labelWidth={LABEL_WIDTH}
-          interactive={true}
-          tooltip="(Caution) This is a alpha feature. Live feature provides live updating with PVWS WebSocket server."
-        >
-          <InlineSwitch value={options.jsonData.useLiveUpdate ?? false} onChange={this.onUseLiveUpdateChange} />
-        </InlineField>
-        <InlineField
-          label="PVWS URI (Alpha)"
-          labelWidth={LABEL_WIDTH}
-          interactive={true}
-          tooltip="URI for PVWS WebSocket server."
-        >
-          <input
-            type="text"
-            value={options.jsonData.liveUpdateURI}
-            className="gf-form-input max-width-15"
-            placeholder="ws://localhost:8080/pvws/pv"
-            onChange={this.onLiveUpdateURIChange}
-          />
-        </InlineField>
+                <Switch value={options.jsonData.useBackend ?? false} onChange={this.onUseBEChange} />
+              </Field>
+
+              <Field
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>Default Operator</span>
+                      <Tooltip
+                        content={
+                          <p>
+                            Controls processing of data during data retrieval. Refer{' '}
+                            <a
+                              href="https://epicsarchiver.readthedocs.io/en/latest/user/userguide.html#processing-of-data"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Archiver Appliance User Guide
+                            </a>{' '}
+                            <code>raw</code> allows to retrieve the data without processing. <code>last</code> allows to
+                            retrieve the last data in the specified time range.
+                          </p>
+                        }
+                      >
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
+              >
+                <Combobox
+                  value={options.jsonData.defaultOperator}
+                  options={operatorOptions}
+                  width={40}
+                  onChange={this.onOperatorChange}
+                  placeholder="mean"
+                />
+              </Field>
+
+              <Field
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>Hide Invalid</span>
+                      <Tooltip content={<span>Hide sample data whose severity is invalid with a null value.</span>}>
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
+              >
+                <Switch value={options.jsonData.hideInvalid ?? false} onChange={this.onHideInvalidChange} />
+              </Field>
+            </ConfigSubSection>
+
+            <ConfigSubSection title="Live Feature Options">
+              <Field
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>Use live feature (Alpha)</span>
+                      <Tooltip
+                        content={
+                          <span>
+                            (Caution) This is an alpha feature. Live feature provides live updating with PVWS WebSocket
+                            server.
+                          </span>
+                        }
+                      >
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
+              >
+                <Switch value={options.jsonData.useLiveUpdate ?? false} onChange={this.onUseLiveUpdateChange} />
+              </Field>
+
+              <Field
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>PVWS URI (Alpha)</span>
+                      <Tooltip content={<span>URI for PVWS WebSocket server.</span>}>
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
+              >
+                <Input
+                  value={options.jsonData.liveUpdateURI}
+                  placeholder="ws://localhost:8080/pvws/pv"
+                  width={40}
+                  onChange={this.onLiveUpdateURIChange}
+                />
+              </Field>
+            </ConfigSubSection>
+          </Stack>
+        </ConfigSection>
       </>
     );
   }

--- a/src/components/FunctionParam.tsx
+++ b/src/components/FunctionParam.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { SegmentInput, Segment } from '@grafana/ui';
-import { toSelectableValue } from './toSelectableValue';
+import { toSelectableValue } from './utils';
 
 export interface FunctionParamProps {
   param: string;
@@ -13,7 +13,13 @@ export interface FunctionParamProps {
   onRunQuery: () => void;
 }
 
-export const FunctionParam = ({ param, paramDef, index, onChange, onRunQuery }: FunctionParamProps): React.JSX.Element => {
+export const FunctionParam = ({
+  param,
+  paramDef,
+  index,
+  onChange,
+  onRunQuery,
+}: FunctionParamProps): React.JSX.Element => {
   const onInputChange = (paramIndex: number, value: any) => {
     onChange(paramIndex, String(value));
     onRunQuery();

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -104,7 +104,10 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
   const useLiveUpdate = datasource.useLiveUpdate || false;
   const customStyles = useStyles2(getStyles);
 
-  const inputClass = cx({
+  const pvInputClass = cx({
+    [customStyles.inputRegexp]: query_.regex,
+  });
+  const aliasInputClass = cx({
     [customStyles.inputRegexp]: Boolean(query_.aliasPattern),
   });
 
@@ -122,15 +125,17 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
             </p>
           }
         >
-          <Combobox
-            width={56}
-            value={pvOptionValue}
-            options={debounceLoadSuggestions}
-            createCustomValue
-            isClearable
-            onChange={onPVChange}
-            placeholder="PV name"
-          />
+          <div className={pvInputClass}>
+            <Combobox
+              width={56}
+              value={pvOptionValue}
+              options={debounceLoadSuggestions}
+              createCustomValue
+              isClearable
+              onChange={onPVChange}
+              placeholder="PV name"
+            />
+          </div>
         </InlineField>
         <InlineField
           labelWidth={12}
@@ -240,7 +245,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
             onChange={onAliasChange}
             onBlur={onRunQuery}
             onKeyDown={onKeydownEnter}
-            className={inputClass}
+            className={aliasInputClass}
           />
         </InlineField>
         <InlineField

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,9 +1,9 @@
 import defaults from 'lodash/defaults';
+import { css, cx } from '@emotion/css';
 import debounce from 'debounce-promise';
 import React, { ChangeEvent, KeyboardEvent, useState } from 'react';
-import { InlineSwitch, Input, InlineField, Combobox, ComboboxOption } from '@grafana/ui';
-import { QueryEditorProps } from '@grafana/data';
-import { InlineFieldRow } from '@grafana/ui';
+import { InlineFieldRow, InlineSwitch, Input, InlineField, Combobox, ComboboxOption, useStyles2 } from '@grafana/ui';
+import { QueryEditorProps, GrafanaTheme2 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../DataSource';
 import { AADataSourceOptions, AAQuery, defaultQuery, operatorList, FunctionDescriptor } from '../types';
@@ -13,7 +13,6 @@ import { toComboboxOption } from './utils';
 
 type Props = QueryEditorProps<DataSource, AAQuery, AADataSourceOptions>;
 
-const colorYellow = '#d69e2e';
 const operatorOptions: Array<ComboboxOption<string>> = operatorList.map(toComboboxOption);
 
 export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props): React.JSX.Element => {
@@ -103,7 +102,11 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
   const query_ = defaults(query, defaultQuery);
   const defaultOperator = datasource.defaultOperator || 'mean';
   const useLiveUpdate = datasource.useLiveUpdate || false;
-  const aliasInputStyle = query_.aliasPattern ? { color: colorYellow } : {};
+  const customStyles = useStyles2(getStyles);
+
+  const inputClass = cx({
+    [customStyles.inputRegexp]: Boolean(query_.aliasPattern),
+  });
 
   return (
     <>
@@ -234,10 +237,10 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
             value={query.alias}
             width={56}
             placeholder="Alias"
-            style={aliasInputStyle}
             onChange={onAliasChange}
             onBlur={onRunQuery}
             onKeyDown={onKeydownEnter}
+            className={inputClass}
           />
         </InlineField>
         <InlineField
@@ -264,14 +267,24 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
             value={query.aliasPattern}
             width={52}
             placeholder="Alias regex pattern"
-            style={{ color: colorYellow }}
             onChange={onAliaspatternChange}
             onBlur={onRunQuery}
             onKeyDown={onKeydownEnter}
+            className={customStyles.inputRegexp}
           />
         </InlineField>
       </InlineFieldRow>
       <Functions funcs={query.functions} onChange={onFuncsChange} onRunQuery={onRunQuery} />
     </>
   );
+};
+
+export const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    inputRegexp: css`
+      input {
+        color: ${theme.colors.warning.main};
+      }
+    `,
+  };
 };

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -46,7 +46,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource }: Props):
 
   const onOperatorChange = (option: ComboboxOption | null) => {
     if (option === null) {
-      onChange({ ...query, operator: defaultOperator });
+      onChange({ ...query, operator: '' });
       setOperatorOptionValue(undefined);
     } else {
       onChange({ ...query, operator: option.value });

--- a/src/components/toSelectableValue.ts
+++ b/src/components/toSelectableValue.ts
@@ -1,5 +1,0 @@
-import { SelectableValue } from '@grafana/data';
-
-export function toSelectableValue<T extends string>(t: T): SelectableValue<T> {
-  return { label: t, value: t };
-}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,6 @@
+import { ComboboxOption } from '@grafana/ui';
+
+export const toComboboxOption = (value: string): ComboboxOption => ({
+  label: value,
+  value,
+});

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,6 +1,11 @@
+import { SelectableValue } from '@grafana/data';
 import { ComboboxOption } from '@grafana/ui';
 
 export const toComboboxOption = (value: string): ComboboxOption => ({
   label: value,
   value,
 });
+
+export function toSelectableValue<T extends string>(t: T): SelectableValue<T> {
+  return { label: t, value: t };
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,8 +37,8 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=9.0.0",
-    "grafanaVersion": "9.x.x",
+    "grafanaDependency": ">=12.0.0",
+    "grafanaVersion": "12.x.x",
     "plugins": []
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,10 +259,23 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/polyfill@^7.6.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
+  integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.0", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.0", "@babel/runtime@^7.20.7", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.24.5", "@babel/runtime@^7.24.7", "@babel/runtime@^7.25.6", "@babel/runtime@^7.25.7", "@babel/runtime@^7.26.10", "@babel/runtime@^7.27.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
+
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.27.0", "@babel/runtime@^7.9.2":
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.2.tgz#2ae5a9d51cc583bd1f5673b3bb70d6d819682473"
+  integrity sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==
 
 "@babel/template@^7.27.2":
   version "7.27.2"
@@ -394,7 +407,7 @@
     "@emotion/weak-memoize" "^0.4.0"
     stylis "4.2.0"
 
-"@emotion/css@11.13.5", "@emotion/css@^11.13.5":
+"@emotion/css@11.13.5", "@emotion/css@^11.11.2", "@emotion/css@^11.13.5":
   version "11.13.5"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.13.5.tgz#db2d3be6780293640c082848e728a50544b9dfa4"
   integrity sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==
@@ -666,6 +679,24 @@
     uuid "^11.0.2"
     yaml "^2.3.4"
 
+"@grafana/plugin-ui@^0.10.7":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-ui/-/plugin-ui-0.10.7.tgz#db0ed763a472d68cfda94055f52c095834465b5f"
+  integrity sha512-EUUCp2502h54S2I4D7Opwe+3TxtMMdkcnleG6V+T0txwFtsxNheDKD+S+8agjN0GiH2oMT4+gky6hBWWfkCJ0A==
+  dependencies:
+    "@emotion/css" "^11.11.2"
+    "@hello-pangea/dnd" "^17.0.0"
+    "@react-awesome-query-builder/ui" "^6.6.4"
+    "@types/prismjs" "^1.26.4"
+    lodash "^4.17.21"
+    prismjs "^1.30.0"
+    react-calendar "^4.8.0"
+    react-popper-tooltip "^4.4.2"
+    react-use "^17.3.1"
+    react-virtualized-auto-sizer "^1.0.6"
+    sql-formatter-plus "^1.3.6"
+    uuid "^11.0.0"
+
 "@grafana/runtime@^12.0.2":
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-12.0.2.tgz#b875321d206d8b0c687a2f61b232e5a3cbcd7118"
@@ -770,7 +801,7 @@
     uuid "11.0.5"
     uwrap "0.1.1"
 
-"@hello-pangea/dnd@17.0.0":
+"@hello-pangea/dnd@17.0.0", "@hello-pangea/dnd@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@hello-pangea/dnd/-/dnd-17.0.0.tgz#2dede20fd6d8a9b53144547e6894fc482da3d431"
   integrity sha512-LDDPOix/5N0j5QZxubiW9T0M0+1PR0rTDWeZF5pu1Tz91UQnuVK4qQ/EjY83Qm2QeX0eM8qDXANfDh3VVqtR4Q==
@@ -1425,7 +1456,7 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@popperjs/core@2.11.8":
+"@popperjs/core@2.11.8", "@popperjs/core@^2.11.5":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
@@ -1637,6 +1668,34 @@
     "@react-aria/utils" "^3.30.0"
     "@react-types/shared" "^3.31.0"
     "@swc/helpers" "^0.5.0"
+
+"@react-awesome-query-builder/core@^6.6.15":
+  version "6.6.15"
+  resolved "https://registry.yarnpkg.com/@react-awesome-query-builder/core/-/core-6.6.15.tgz#26f3aa2792140b60864d0206d5d1c039222ebd5d"
+  integrity sha512-vAAEvuoAXRgpX2oN6Uovs5cblvMUePjxweCEa6j9t5QQ4qtn9X7lxaX+5RoMVSiVU5z4Ca2XwxtutEeuY+j6zg==
+  dependencies:
+    "@babel/runtime" "^7.27.0"
+    clone "^2.1.2"
+    i18next "^23.11.5"
+    immutable "^4.3.6"
+    json-logic-js "^2.0.2"
+    lodash "^4.17.21"
+    moment "^2.30.1"
+    spel2js "^0.2.8"
+    sqlstring "^2.3.3"
+
+"@react-awesome-query-builder/ui@^6.6.4":
+  version "6.6.15"
+  resolved "https://registry.yarnpkg.com/@react-awesome-query-builder/ui/-/ui-6.6.15.tgz#2bb2dc9f6554b7ff09445b80506659580cb3dcde"
+  integrity sha512-7mkyz+fnVWz1VFvmlYPa9CV2fQhayM8PkcYzymoRTGKiY11WWaAnE49PhCENZV3+48CvnF1z1Dv86Npatl5Lpw==
+  dependencies:
+    "@babel/runtime" "^7.27.0"
+    "@react-awesome-query-builder/core" "^6.6.15"
+    classnames "^2.5.1"
+    lodash "^4.17.21"
+    prop-types "^15.8.1"
+    react-redux "^8.1.3"
+    redux "^4.2.1"
 
 "@react-stately/flags@^3.1.0", "@react-stately/flags@^3.1.2":
   version "3.1.2"
@@ -1970,6 +2029,13 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz#306e3a3a73828522efa1341159da4846e7573a6c"
+  integrity sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==
+  dependencies:
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -2050,6 +2116,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
+"@types/prismjs@^1.26.4":
+  version "1.26.5"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.5.tgz#72499abbb4c4ec9982446509d2f14fb8483869d6"
+  integrity sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==
+
 "@types/react-router-dom@^5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
@@ -2115,6 +2186,11 @@
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
@@ -3023,7 +3099,7 @@ cjs-module-lexer@^2.1.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz#586e87d4341cb2661850ece5190232ccdebcff8b"
   integrity sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==
 
-classnames@2.5.1, classnames@2.x, classnames@^2.2.1, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1, classnames@^2.3.2:
+classnames@2.5.1, classnames@2.x, classnames@^2.2.1, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1, classnames@^2.3.2, classnames@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
@@ -3045,6 +3121,11 @@ clone-deep@^4.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
+
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
 clsx@^2.0.0:
   version "2.1.1"
@@ -3150,6 +3231,11 @@ copy-webpack-plugin@^13.0.0:
     schema-utils "^4.2.0"
     serialize-javascript "^6.0.2"
     tinyglobby "^0.2.12"
+
+core-js@^2.6.5:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -4627,7 +4713,7 @@ history@^5.3.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@3.3.2, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@3.3.2, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4691,6 +4777,13 @@ i18next-browser-languagedetector@^8.0.0:
   dependencies:
     "@babel/runtime" "^7.23.2"
 
+i18next@^23.11.5:
+  version "23.16.8"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.8.tgz#3ae1373d344c2393f465556f394aba5a9233b93a"
+  integrity sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
 i18next@^24.0.0:
   version "24.2.3"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-24.2.3.tgz#3a05f72615cbd7c00d7e348667e2aabef1df753b"
@@ -4736,6 +4829,11 @@ immutable@5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.0.3.tgz#aa037e2313ea7b5d400cd9298fa14e404c933db1"
   integrity sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==
+
+immutable@^4.3.6:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
+  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
 
 immutable@^5.0.2:
   version "5.1.3"
@@ -5647,6 +5745,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-logic-js@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/json-logic-js/-/json-logic-js-2.0.5.tgz#55f0c687dd6f56b02ccdcfdd64171ed998ab5499"
+  integrity sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==
+
 json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -5765,7 +5868,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.21, lodash@^4.1.1, lodash@^4.17.21, lodash@^4.17.4:
+lodash@4.17.21, lodash@^4.1.1, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5983,7 +6086,7 @@ moment-timezone@0.5.47:
   dependencies:
     moment "^2.29.4"
 
-moment@2.30.1, moment@^2.29.4:
+moment@2.30.1, moment@^2.29.4, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
@@ -6449,7 +6552,7 @@ pretty-format@30.0.5, pretty-format@^30.0.0:
     ansi-styles "^5.2.0"
     react-is "^18.3.1"
 
-prismjs@1.30.0:
+prismjs@1.30.0, prismjs@^1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
@@ -6676,6 +6779,17 @@ rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
 
+react-calendar@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-4.8.0.tgz#61edbba6d17e7ef8a8012de9143b5e5ff41104c8"
+  integrity sha512-qFgwo+p58sgv1QYMI1oGNaop90eJVKuHTZ3ZgBfrrpUb+9cAexxsKat0sAszgsizPMVo7vOXedV7Lqa0GQGMvA==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    prop-types "^15.6.0"
+    warning "^4.0.0"
+
 react-calendar@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-5.1.0.tgz#f5d3342a872cbb8907099ca5651bc936046033b8"
@@ -6722,6 +6836,11 @@ react-dropzone@14.3.5:
     attr-accept "^2.2.4"
     file-selector "^2.1.0"
     prop-types "^15.8.1"
+
+react-fast-compare@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-from-dom@^0.7.5:
   version "0.7.5"
@@ -6773,7 +6892,7 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^18.2.0, react-is@^18.3.1:
+react-is@^18.0.0, react-is@^18.2.0, react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
@@ -6782,6 +6901,35 @@ react-loading-skeleton@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz#da2090355b4dedcad5c53cb3f0ed364e3a76d6ca"
   integrity sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==
+
+react-popper-tooltip@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-4.4.2.tgz#0dc4894b8e00ba731f89bd2d30584f6032ec6163"
+  integrity sha512-y48r0mpzysRTZAIh8m2kpZ8S1YPNqGtQPDrlXYSGvDS1c1GpG/NUXbsbIdfbhXfmSaRJuTcaT6N1q3CKuHRVbg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@popperjs/core" "^2.11.5"
+    react-popper "^2.3.0"
+
+react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
+
+react-redux@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.3.tgz#4fdc0462d0acb59af29a13c27ffef6f49ab4df46"
+  integrity sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    hoist-non-react-statics "^3.3.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react-redux@^9.1.2:
   version "9.2.0"
@@ -6885,7 +7033,7 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@17.6.0:
+react-use@17.6.0, react-use@^17.3.1:
   version "17.6.0"
   resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.6.0.tgz#2101a3a79dc965a25866b21f5d6de4b128488a14"
   integrity sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==
@@ -6904,6 +7052,11 @@ react-use@17.6.0:
     throttle-debounce "^3.0.1"
     ts-easing "^0.2.0"
     tslib "^2.1.0"
+
+react-virtualized-auto-sizer@^1.0.6:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz#e9470ef6a778dc4f1d5fd76305fa2d8b610c357a"
+  integrity sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==
 
 react-window@1.8.11:
   version "1.8.11"
@@ -6938,6 +7091,13 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 redux@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
@@ -6956,6 +7116,11 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
     get-intrinsic "^1.2.7"
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
+
+regenerator-runtime@^0.13.4:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
@@ -7468,10 +7633,28 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz#6d6e980c9df2b6fc905343a3b2d702a6239536c3"
   integrity sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==
 
+spel2js@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/spel2js/-/spel2js-0.2.8.tgz#3ba3b291e5c6bae5c9f703e839294969b61fc691"
+  integrity sha512-dzYq+v4YV7SPIdNrmvFAUjc0HcgI7b0yoMw7kzOBmlj/GjdOb/+8dVn1I7nLuOS5X2SW+LK3tf2SVkXRjCkWBA==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sql-formatter-plus@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/sql-formatter-plus/-/sql-formatter-plus-1.3.6.tgz#56e671181ff34c0dc403bac6f950486626f9d406"
+  integrity sha512-3pelcpLve9GgsXshWL/59zyDkhICkXDURKjXyUN+PJqVGAt+ZmNPB2JY+hgnaQG5X9TQI7Q+WiyLEprHQAWuaQ==
+  dependencies:
+    "@babel/polyfill" "^7.6.0"
+    lodash "^4.17.15"
+
+sqlstring@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.3.tgz#2ddc21f03bce2c387ed60680e739922c65751d0c"
+  integrity sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==
 
 stack-generator@^2.0.5:
   version "2.0.10"
@@ -8116,7 +8299,7 @@ use-memo-one@^1.1.3:
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
   integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
-use-sync-external-store@^1.4.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
@@ -8131,7 +8314,7 @@ uuid@11.0.5:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
   integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
 
-uuid@^11.0.2, uuid@^11.1.0:
+uuid@^11.0.0, uuid@^11.0.2, uuid@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
@@ -8179,7 +8362,7 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warning@^4.0.0:
+warning@^4.0.0, warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
Select[1] and DataSourceHttpSettings[2] are deprecated UI components.

This PR migrates from the deprecated components to the supported components.

[1] [11.6.x to 12.0.x | Grafana Plugin Tools](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-11_6_x-to-12_0_x#migrate-from-select-to-combobox)
[2] [Migrating from DataSourceHttpSettings component](https://github.com/grafana/plugin-ui/blob/8c40b12c21f8dd01bc1840804ecf4536009429cd/src/components/ConfigEditor/migrating-from-datasource-http-settings.md)